### PR TITLE
Add Linkerd service profile to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/stefanprodan/podinfo)](https://goreportcard.com/report/github.com/stefanprodan/podinfo)
 [![Docker Pulls](https://img.shields.io/docker/pulls/stefanprodan/podinfo)](https://hub.docker.com/r/stefanprodan/podinfo)
 
-Podinfo is a tiny web application made with Go 
-that showcases best practices of running microservices in Kubernetes.
+Podinfo is a tiny web application made with Go that showcases best practices of running microservices in Kubernetes.
 
 Specifications:
 
@@ -14,6 +13,7 @@ Specifications:
 * File watcher for secrets and configmaps
 * Instrumented with Prometheus
 * Tracing with Istio and Jaeger
+* Linkerd service profile
 * Structured logging with zap 
 * 12-factor app with viper
 * Fault injection (random errors and latency)

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 3.1.2
-appVersion: 3.1.2
+version: 3.1.3
+appVersion: 3.1.3
 name: podinfo
 engine: gotpl
 description: Podinfo Helm chart for Kubernetes

--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -66,6 +66,7 @@ Parameter | Description | Default
 `tolerations` | list of node taints to tolerate | `[]`
 `serviceAccount.enabled` | specifies whether a service account should be created | `false`
 `serviceAccount.name` | the name of the service account to use, if not set and create is true, a name is generated using the fullname template | None
+`linkerd.profile.enabled` | create Linkerd service profile | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/podinfo/templates/linkerd.yaml
+++ b/charts/podinfo/templates/linkerd.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.linkerd.profile.enabled -}}
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: {{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+spec:
+  routes:
+    - condition:
+        method: GET
+        pathRegex: /
+      name: GET /
+    - condition:
+        method: POST
+        pathRegex: /api/echo
+      name: POST /api/echo
+    - condition:
+        method: GET
+        pathRegex: /api/info
+      name: GET /api/info
+    - condition:
+        method: GET
+        pathRegex: /chunked/[^/]*
+      name: GET /chunked/{seconds}
+    - condition:
+        method: GET
+        pathRegex: /delay/[^/]*
+      name: GET /delay/{seconds}
+    - condition:
+        method: GET
+        pathRegex: /env
+      name: GET /env
+    - condition:
+        method: GET
+        pathRegex: /headers
+      name: GET /headers
+    - condition:
+        method: GET
+        pathRegex: /healthz
+      name: GET /healthz
+    - condition:
+        method: GET
+        pathRegex: /metrics
+      name: GET /metrics
+    - condition:
+        method: GET
+        pathRegex: /panic
+      name: GET /panic
+    - condition:
+        method: GET
+        pathRegex: /readyz
+      name: GET /readyz
+    - condition:
+        method: POST
+        pathRegex: /readyz/disable
+      name: POST /readyz/disable
+    - condition:
+        method: POST
+        pathRegex: /readyz/enable
+      name: POST /readyz/enable
+    - condition:
+        method: GET
+        pathRegex: /status/[^/]*
+      name: GET /status/{code}
+    - condition:
+        method: POST
+        pathRegex: /store
+      name: POST /store
+    - condition:
+        method: GET
+        pathRegex: /store/[^/]*
+      name: GET /store/{hash}
+    - condition:
+        method: POST
+        pathRegex: /token
+      name: POST /token
+    - condition:
+        method: POST
+        pathRegex: /token/validate
+      name: POST /token/validate
+    - condition:
+        method: GET
+        pathRegex: /version
+      name: GET /version
+    - condition:
+        method: POST
+        pathRegex: /ws/echo
+      name: POST /ws/echo
+{{- end }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -16,7 +16,7 @@ faults:
 
 image:
   repository: stefanprodan/podinfo
-  tag: 3.1.2
+  tag: 3.1.3
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -47,6 +47,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+linkerd:
+  profile:
+    enabled: false
+
 ingress:
   enabled: false
   annotations: {}

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: stefanprodan/podinfo:3.1.2
+        image: stefanprodan/podinfo:3.1.3
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "3.1.2"
+var VERSION = "3.1.3"
 var REVISION = "unknown"


### PR DESCRIPTION
Enable Linkerd per-route metrics by adding a service profile for podinfo API.