### PR TITLE
e2e: Update Helm to v3 and Kubernetes to v1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           name: Start Kubernetes Kind cluster
           command: e2e/bootstrap.sh
       - run:
-          name: Install podinfo with Helm
+          name: Install podinfo with Helm v3
           command: e2e/install.sh
       - run:
           name: Run Helm tests

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,11 +7,11 @@ The e2e testing infrastructure is powered by CircleCI and [Kubernetes Kind](http
 * download go modules
 * run unit tests
 * build container
-* install kubectl, helm and Kubernetes Kind CLIs
+* install kubectl, Helm v3 and Kubernetes Kind CLIs
 * create local Kubernetes cluster with kind
-* deploy Tiller on the local cluster
 * load podinfo image onto the local cluster
 * deploy podinfo with Helm
+* set the podinfo image to the locally built one
 * run Helm tests
 
 ```yaml

--- a/e2e/bootstrap.sh
+++ b/e2e/bootstrap.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=v0.5.1
+KIND_VERSION=v0.7.0
 
 if [[ "$1" ]]; then
   KIND_VERSION=$1
@@ -22,13 +22,5 @@ sudo mv kind /usr/local/bin/kind
 echo ">>> Creating kind cluster"
 kind create cluster --wait 5m
 
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-kubectl get pods --all-namespaces
-
-echo ">>> Installing Helm"
-curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-
-echo '>>> Installing Tiller'
-kubectl --namespace kube-system create sa tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-helm init --service-account tiller --upgrade --wait
+echo ">>> Installing Helm v3"
+curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash

--- a/e2e/install.sh
+++ b/e2e/install.sh
@@ -3,7 +3,6 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 
 echo '>>> Loading image in Kind'
 kind load docker-image test/podinfo:latest

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -2,15 +2,11 @@
 
 set -o errexit
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-
 function finish {
   echo '>>> Test logs'
   kubectl logs -l app=podinfo
 }
 trap finish EXIT
 
-echo '>>> Testing'
+echo '>>> Start integration tests'
 helm test podinfo
-


### PR DESCRIPTION
CircleCI workflow:
* download go modules
* run unit tests
* build container
* install kubectl, Helm v3 and Kubernetes Kind CLIs
* create local Kubernetes v1.17 cluster with kind
* load podinfo image onto the local cluster
* deploy podinfo with Helm v3
* set the podinfo image to the locally built one
* run integration tests with Helm