### PR TITLE
Feature/support helm3 test hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ helm upgrade --install --wait frontend \
 --set backend=http://backend-podinfo:9898/echo \
 podinfo/podinfo
 
-helm test frontend --cleanup
+# Test pods have hook-delete-policy: hook-succeeded
+helm test frontend
 
 helm upgrade --install --wait backend \
 --namespace test \

--- a/charts/podinfo/templates/tests/grpc.yaml
+++ b/charts/podinfo/templates/tests/grpc.yaml
@@ -8,7 +8,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled

--- a/charts/podinfo/templates/tests/jwt.yaml
+++ b/charts/podinfo/templates/tests/jwt.yaml
@@ -8,7 +8,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled

--- a/charts/podinfo/templates/tests/service.yaml
+++ b/charts/podinfo/templates/tests/service.yaml
@@ -8,7 +8,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled


### PR DESCRIPTION
Updated test templates so it uses `hook: test` and also added `hook-delete-policy: before-hook-creation,hook-succeeded`