### PR TITLE
Release v3.2.2

### DIFF
--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 3.2.1
-appVersion: 3.2.1
+version: 3.2.2
+appVersion: 3.2.2
 name: podinfo
 engine: gotpl
 description: Podinfo Helm chart for Kubernetes

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -21,7 +21,7 @@ h2c:
 
 image:
   repository: stefanprodan/podinfo
-  tag: 3.2.1
+  tag: 3.2.2
   pullPolicy: IfNotPresent
 
 service:

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: stefanprodan/podinfo:3.2.1
+        image: stefanprodan/podinfo:3.2.2
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "3.2.1"
+var VERSION = "3.2.2"
 var REVISION = "unknown"


### PR DESCRIPTION
Helm chart breaking change due to label selectors changes, use `helm upgrade --force `.