### PR TITLE
Quote ui message in deployment template

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           env:
           {{- if .Values.ui.message }}
           - name: PODINFO_UI_MESSAGE
-            value: {{ .Values.ui.message }}
+            value: {{ quote .Values.ui.message }}
           {{- end }}
           {{- if .Values.ui.logo }}
           - name: PODINFO_UI_LOGO


### PR DESCRIPTION
* To handle rare situation of digit-only message like 270 and
avoid associated failure during helm install
```
ReadString: expects " or n, but found 2, error found in #10 byte of ...|,"value":270},
{"name|..., bigger context ...|se"],"env":[{"name":"PODINFO_UI_MESSAGE","value":270},
```