### PR TITLE
Push base image to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin;
             echo $QUAY_PASS | docker login -u $QUAY_USER --password-stdin quay.io;
             make push-container;
+            make push-base;
           fi
 
   push-binary:

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,10 @@
+FROM golang:1.14
+
+WORKDIR /workspace
+
+# copy modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# cache modules
+RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ build-charts:
 build-container:
 	docker build -t $(DOCKER_IMAGE_NAME):$(VERSION) .
 
+build-base:
+	docker build -f Dockerfile.base -t $(DOCKER_REPOSITORY)/podinfo-base:latest .
+
+push-base: build-base
+	docker push $(DOCKER_REPOSITORY)/podinfo-base:latest
+
 test-container:
 	@docker rm -f podinfo || true
 	@docker run -dp 9898:9898 --name=podinfo $(DOCKER_IMAGE_NAME):$(VERSION)

--- a/deploy/bases/frontend/hpa.yaml
+++ b/deploy/bases/frontend/hpa.yaml
@@ -6,7 +6,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: backend
+    name: frontend
   minReplicas: 1
   maxReplicas: 4
   metrics:


### PR DESCRIPTION
Build and push podinfo base image to Docker Hub after each release. The base image contains a cache of podinfo go modules.