### PR TITLE
Add cache routes to Linkerd profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Web API:
 * `GET /token/validate` validates the JWT token `curl -H "Authorization: Bearer $JWT" podinfo:9898/token/validate`
 * `GET /configs` returns a JSON with configmaps and/or secrets mounted in the `config` volume
 * `POST /cache` saves the posted content to Redis and returns the SHA1 hash of the content
-* `GET /store/{hash}` returns the content from Redis if the key exists
+* `GET /cache/{hash}` returns the content from Redis if the key exists
 * `POST /store` writes the posted content to disk at /data/hash and returns the SHA1 hash of the content
 * `GET /store/{hash}` returns the content of the file /data/hash if exists
 * `GET /ws/echo` echos content via websockets `podcli ws ws://localhost:9898/ws/echo`

--- a/charts/podinfo/templates/ingress.yaml
+++ b/charts/podinfo/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "podinfo.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/podinfo/templates/linkerd.yaml
+++ b/charts/podinfo/templates/linkerd.yaml
@@ -63,6 +63,14 @@ spec:
       name: GET /status/{code}
     - condition:
         method: POST
+        pathRegex: /cache
+      name: POST /cache
+    - condition:
+        method: GET
+        pathRegex: /cache/[^/]*
+      name: GET /cache/{hash}
+    - condition:
+        method: POST
         pathRegex: /store
       name: POST /store
     - condition:

--- a/charts/podinfo/templates/tests/fail.yaml
+++ b/charts/podinfo/templates/tests/fail.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.faults.test }}
+{{- if .Values.faults.testFail }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/podinfo/templates/tests/timeout.yaml
+++ b/charts/podinfo/templates/tests/timeout.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.faults.test }}
+{{- if .Values.faults.testTimeout }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/e2e/bootstrap.sh
+++ b/e2e/bootstrap.sh
@@ -3,7 +3,7 @@
 set -o errexit
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KIND_VERSION=v0.7.0
+KIND_VERSION=v0.8.1
 
 if [[ "$1" ]]; then
   KIND_VERSION=$1


### PR DESCRIPTION
Changes:
- add cache routes to Linkerd profile
- fix Helm tests 
- update ingress API version to `networking.k8s.io/v1beta1`
- update Kubernetes e2e tests to Kind v0.8.1