### PR TITLE
Reverts tests as Jobs

### DIFF
--- a/charts/podinfo/templates/tests/fail.yaml
+++ b/charts/podinfo/templates/tests/fail.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.faults.testFail }}
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-fault-test-{{ randAlphaNum 5 | lower }}
   labels:
@@ -15,12 +15,10 @@ metadata:
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 spec:
-  template:
-    spec:
-      containers:
-        - name: fault
-          image: alpine:3.11
-          command: ['/bin/sh']
-          args:  ['-c', 'exit 1']
-      restartPolicy: Never
+  containers:
+    - name: fault
+      image: alpine:3.11
+      command: ['/bin/sh']
+      args:  ['-c', 'exit 1']
+  restartPolicy: Never
 {{- end }}

--- a/charts/podinfo/templates/tests/grpc.yaml
+++ b/charts/podinfo/templates/tests/grpc.yaml
@@ -1,5 +1,5 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-grpc-test-{{ randAlphaNum 5 | lower }}
   labels:
@@ -14,11 +14,9 @@ metadata:
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 spec:
-  template:
-    spec:
-      containers:
-        - name: grpc-health-probe
-          image: stefanprodan/grpc_health_probe:v0.3.0
-          command: ['grpc_health_probe']
-          args:  ['-addr={{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.grpcPort }}']
-      restartPolicy: Never
+  containers:
+    - name: grpc-health-probe
+      image: stefanprodan/grpc_health_probe:v0.3.0
+      command: ['grpc_health_probe']
+      args:  ['-addr={{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.grpcPort }}']
+  restartPolicy: Never

--- a/charts/podinfo/templates/tests/jwt.yaml
+++ b/charts/podinfo/templates/tests/jwt.yaml
@@ -1,5 +1,5 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-jwt-test-{{ randAlphaNum 5 | lower }}
   labels:
@@ -14,18 +14,16 @@ metadata:
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 spec:
-  template:
-    spec:
-      containers:
-        - name: tools
-          image: giantswarm/tiny-tools
-          command:
-            - sh
-            - -c
-            - |
-              TOKEN=$(curl -sd 'test' ${PODINFO_SVC}/token | jq -r .token) &&
-              curl -sH "Authorization: Bearer ${TOKEN}" ${PODINFO_SVC}/token/validate | grep test
-          env:
-          - name: PODINFO_SVC
-            value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
-      restartPolicy: Never
+  containers:
+    - name: tools
+      image: giantswarm/tiny-tools
+      command:
+        - sh
+        - -c
+        - |
+          TOKEN=$(curl -sd 'test' ${PODINFO_SVC}/token | jq -r .token) &&
+          curl -sH "Authorization: Bearer ${TOKEN}" ${PODINFO_SVC}/token/validate | grep test
+      env:
+      - name: PODINFO_SVC
+        value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
+  restartPolicy: Never

--- a/charts/podinfo/templates/tests/service.yaml
+++ b/charts/podinfo/templates/tests/service.yaml
@@ -1,5 +1,5 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-service-test-{{ randAlphaNum 5 | lower }}
   labels:
@@ -14,17 +14,15 @@ metadata:
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 spec:
-  template:
-    spec:
-      containers:
-        - name: curl
-          image: curlimages/curl:7.69.0
-          command:
-            - sh
-            - -c
-            - |
-              curl -s ${PODINFO_SVC}/api/info | grep version
-          env:
-            - name: PODINFO_SVC
-              value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
-      restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:7.69.0
+      command:
+        - sh
+        - -c
+        - |
+          curl -s ${PODINFO_SVC}/api/info | grep version
+      env:
+        - name: PODINFO_SVC
+          value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
+  restartPolicy: Never

--- a/charts/podinfo/templates/tests/timeout.yaml
+++ b/charts/podinfo/templates/tests/timeout.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.faults.testTimeout }}
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-fault-test-{{ randAlphaNum 5 | lower }}
   labels:
@@ -15,12 +15,10 @@ metadata:
     linkerd.io/inject: disabled
     appmesh.k8s.aws/sidecarInjectorWebhook: disabled
 spec:
-  template:
-    spec:
-      containers:
-        - name: fault
-          image: alpine:3.11
-          command: ['/bin/sh']
-          args:  ['-c', 'while sleep 3600; do :; done']
-      restartPolicy: Never
+  containers:
+    - name: fault
+      image: alpine:3.11
+      command: ['/bin/sh']
+      args:  ['-c', 'while sleep 3600; do :; done']
+  restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
This reverts the #61 change to use test Jobs, which was premature
since this feature hasn't been back ported to Helm 2 yet, which
leads to the tests not being run there.

It would be possible to use presence of .Capabilities.TillerVersion
to implement tests differently for Helm 2 vs 3, but this seems
not worth the trouble.