### PR TITLE
helm tests: Helm 2 support

### DIFF
--- a/charts/podinfo/templates/tests/fail.yaml
+++ b/charts/podinfo/templates/tests/fail.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled

--- a/charts/podinfo/templates/tests/grpc.yaml
+++ b/charts/podinfo/templates/tests/grpc.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled

--- a/charts/podinfo/templates/tests/jwt.yaml
+++ b/charts/podinfo/templates/tests/jwt.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled

--- a/charts/podinfo/templates/tests/service.yaml
+++ b/charts/podinfo/templates/tests/service.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled

--- a/charts/podinfo/templates/tests/timeout.yaml
+++ b/charts/podinfo/templates/tests/timeout.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
-    "helm.sh/hook": test
+    "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     sidecar.istio.io/inject: "false"
     linkerd.io/inject: disabled


### PR DESCRIPTION
The `test-success` hook is supported by Helm 2 and 3.