### PR TITLE
Add CVE scanning with trivy

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -1,0 +1,23 @@
+name: cve-scan
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build image
+        id: build
+        run: |
+          IMAGE=test/podinfo:${GITHUB_SHA}
+          docker build -t ${IMAGE} .
+          echo "::set-output name=image::$IMAGE"
+      - name: Scan image
+        uses: docker://docker.io/aquasec/trivy:latest
+        with:
+          args: --cache-dir /var/lib/trivy --no-progress --exit-code 1 --severity MEDIUM,HIGH,CRITICAL ${{ steps.build.outputs.image }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![e2e](https://github.com/stefanprodan/podinfo/workflows/e2e/badge.svg)](https://github.com/stefanprodan/podinfo/blob/master/.github/workflows/e2e.yml)
 [![test](https://github.com/stefanprodan/podinfo/workflows/test/badge.svg)](https://github.com/stefanprodan/podinfo/blob/master/.github/workflows/test.yml)
-[![release](https://github.com/stefanprodan/podinfo/workflows/release/badge.svg)](https://github.com/stefanprodan/podinfo/blob/master/.github/workflows/release.yml)
+[![cve-scan](https://github.com/stefanprodan/podinfo/workflows/cve-scan/badge.svg)](https://github.com/stefanprodan/podinfo/blob/master/.github/workflows/cve-scan.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/stefanprodan/podinfo)](https://goreportcard.com/report/github.com/stefanprodan/podinfo)
 [![Docker Pulls](https://img.shields.io/docker/pulls/stefanprodan/podinfo)](https://hub.docker.com/r/stefanprodan/podinfo)
 
@@ -24,6 +24,7 @@ Specifications:
 * End-to-End testing with Kubernetes Kind and Helm
 * Kustomize testing with GitHub Actions and Open Policy Agent
 * Multi-arch container image with Docker buildx and Github Actions
+* CVE scanning with trivy
 
 Web API:
 


### PR DESCRIPTION
Add GitHub Action workflow to scan podinfo container image for vulnerabilities using [trivy](https://github.com/aquasecurity/trivy).