### PR TITLE
Enable gRPC reflection protocol

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 type Server struct {
@@ -37,6 +38,7 @@ func (s *Server) ListenAndServe() {
 
 	srv := grpc.NewServer()
 	server := health.NewServer()
+	reflection.Register(srv)
 	grpc_health_v1.RegisterHealthServer(srv, server)
 	server.SetServingStatus(s.config.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
 


### PR DESCRIPTION
**Problem:**
I would like to use a generic gRPC load-tester for canary deployment using podinfo as test service (without requiring to have the protobuf files loaded). 

**Solution:**
Enabling gRPC server reflection protocol allows clients to discover and use the interface as expected.

**Concerns:**
I don't see a reason why it should not be enabled by default. But I am happy to add a switch flag to the arguments list if you prefer that.