### PR TITLE
Ingress Chart: Use .service.externalPort as backend.servicePort

### DIFF
--- a/charts/podinfo/templates/ingress.yaml
+++ b/charts/podinfo/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: {{ .Values.service.externalPort }}
   {{- end }}
   {{- if not .Values.ingress.hosts }}
     - http:
@@ -41,6 +41,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: {{ .Values.service.externalPort }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently the ingress template assumes that the service runs on port 80 while it is not the default port of the service.