### PR TITLE
Always quote the UI color

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
           {{- end }}
           {{- if .Values.ui.color }}
           - name: PODINFO_UI_COLOR
-            value: {{ .Values.ui.color }}
+            value: {{ quote .Values.ui.color }}
           {{- end }}
           {{- if .Values.backend }}
           - name: PODINFO_BACKEND_URL


### PR DESCRIPTION
As otherwise the value will render to `null` for the default chart value due to the `#`.