### PR TITLE
Publish multi-arch image to GHCR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         helm-version:
-          - 2.16.6
-          - 3.2.1
+          - 2.16.12
+          - 3.3.3
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,25 +9,62 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: crazy-max/ghaction-docker-buildx@v1
-      - name: Publish multi-arch image
-        run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          docker buildx build --platform "linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64" \
-            --output "type=image,push=true" \
-            --build-arg "REVISION=${GITHUB_SHA}" \
-            --build-arg "VERSION=${GITHUB_REF#refs/tags/}" \
-            --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-            --tag "docker.io/stefanprodan/podinfo:${GITHUB_REF#refs/tags/}" \
-            --tag "docker.io/stefanprodan/podinfo:latest" \
-            --file Dockerfile .
-      - name: Publish base image
-        uses: docker/build-push-action@v1
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          buildkitd-flags: "--debug"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: stefanprodan/podinfo-base
-          tags: latest
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=sha-${GITHUB_SHA::8}
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF/refs\/tags\//}
+          fi
+          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=VERSION::${VERSION}
+      - name: Publish multi-arch image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          tags: |
+            docker.io/stefanprodan/podinfo:${{ steps.prep.outputs.VERSION }}
+            ghcr.io/stefanprodan/podinfo:${{ steps.prep.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.VERSION }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
+      - name: Publish base image
+        uses: docker/build-push-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          context: .
+          file: ./Dockerfile.base
+          tags: docker.io/stefanprodan/podinfo-base:latest
       - name: Publish helm chart
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,16 +24,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG REVISION
 
-LABEL maintainer="stefanprodan" \
-  org.opencontainers.image.created=$BUILD_DATE \
-  org.opencontainers.image.url="https://github.com/stefanprodan/podinfo" \
-  org.opencontainers.image.source="https://github.com/stefanprodan/podinfo" \
-  org.opencontainers.image.version=$VERSION \
-  org.opencontainers.image.revision=$REVISION \
-  org.opencontainers.image.vendor="stefanprodan" \
-  org.opencontainers.image.title="podinfo" \
-  org.opencontainers.image.description="Go microservice template for Kubernetes" \
-  org.opencontainers.image.licenses="MIT"
+LABEL maintainer="stefanprodan"
 
 RUN addgroup -S app \
     && adduser -S -g app app \


### PR DESCRIPTION
Publish multi-arch image for linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64 to GitHub Container Registry.

Registry: `ghcr.io/stefanprodan/podinfo`.