### PR TITLE
feat(podinfo): add secure port for end-to-end tls

### DIFF
--- a/.github/actions/release-notes/entrypoint.sh
+++ b/.github/actions/release-notes/entrypoint.sh
@@ -20,5 +20,6 @@ main() {
 }
 
 main
-echo "::add-path::$BIN_DIR"
-echo "::add-path::$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin"
+
+echo "$BIN_DIR" >> $GITHUB_PATH
+echo "$RUNNER_WORKSPACE/$(basename $GITHUB_REPOSITORY)/bin" >> $GITHUB_PATH

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
       - name: Build container image
         run: |
           GIT_COMMIT=$(git rev-list -1 HEAD) && \

--- a/cmd/podinfo/main.go
+++ b/cmd/podinfo/main.go
@@ -24,6 +24,7 @@ func main() {
 	// flags definition
 	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
 	fs.Int("port", 9898, "HTTP port")
+	fs.Int("secure-port", 0, "HTTPS port")
 	fs.Int("port-metrics", 0, "metrics port")
 	fs.Int("grpc-port", 0, "gRPC port")
 	fs.String("grpc-service-name", "podinfo", "gPRC service name")
@@ -34,6 +35,7 @@ func main() {
 	fs.Duration("http-server-shutdown-timeout", 5*time.Second, "server graceful shutdown timeout duration")
 	fs.String("data-path", "/data", "data local path")
 	fs.String("config-path", "", "config dir path")
+	fs.String("cert-path", "/data/cert", "certificate path for HTTPS port")
 	fs.String("config", "config.yaml", "config file name")
 	fs.String("ui-path", "./ui", "UI local path")
 	fs.String("ui-logo", "", "UI logo")
@@ -102,6 +104,12 @@ func main() {
 	if _, err := strconv.Atoi(viper.GetString("port")); err != nil {
 		port, _ := fs.GetInt("port")
 		viper.Set("port", strconv.Itoa(port))
+	}
+
+	// validate secure port
+	if _, err := strconv.Atoi(viper.GetString("secure-port")); err != nil {
+		securePort, _ := fs.GetInt("secure-port")
+		viper.Set("secure-port", strconv.Itoa(securePort))
 	}
 
 	// validate random delay options

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,7 @@
-# Deploy demo webapp 
+# Deploy demo webapp
 
 Demo webapp manifests:
+
 - [common](webapp/common)
 - [frontend](webapp/frontend)
 - [backend](webapp/backend)
@@ -29,4 +30,16 @@ Deploy the demo in the `production` namespace:
 
 ```bash
 kustomize build ./overlays/production | kubectl apply -f-
+```
+
+## Testing Locally Using Kind
+
+> NOTE: You can install [kind from here](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+The following will create a new cluster called "podinfo" and configure host ports on 80 and 443. You can access the
+endpoints on localhost. The example also deploys cert-manager within the cluster along with a self-signed cluster issuer
+used to generate the certificate to validate the secure port.
+
+```sh
+./kind.sh
 ```

--- a/deploy/kind.sh
+++ b/deploy/kind.sh
@@ -1,0 +1,49 @@
+#! /usr/bin/env sh
+
+# create the kind cluster
+kind create cluster --config=kind.yaml
+
+# add certificate manager
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
+
+# wait for cert manager webhook
+kubectl wait --namespace cert-manager \
+  --for=condition=available deployment \
+  --selector=app=webhook \
+  --timeout=120s
+
+# wait for the injector
+kubectl wait --namespace cert-manager \
+  --for=condition=available deployment \
+  --selector=app=cainjector \
+  --timeout=120s
+
+# wait for the cert manager
+kubectl wait --namespace cert-manager \
+  --for=condition=available deployment \
+  --selector=app=cert-manager \
+  --timeout=120s
+
+# apply the secure webapp
+kubectl apply -f ./secure/common
+kubectl apply -f ./secure/backend
+kubectl apply -f ./secure/frontend
+
+# wait for the podinfo frontend to come up
+kubectl wait --namespace secure \
+  --for=condition=ready pod \
+  --selector=app=frontend \
+  --timeout=120s
+
+# curl the endpoints (responds with info due to header regexp on route handler)
+echo
+echo "http enpdoint:"
+echo "curl http://localhost"
+echo
+curl http://localhost
+
+echo
+echo "https (secure) enpdoint:"
+echo "curl --insecure https://localhost"
+echo
+curl --insecure https://localhost

--- a/deploy/kind.yaml
+++ b/deploy/kind.yaml
@@ -1,0 +1,11 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP

--- a/deploy/secure/backend/deployment.yaml
+++ b/deploy/secure/backend/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: secure
+spec:
+  minReadySeconds: 3
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
+      labels:
+        app: backend
+    spec:
+      serviceAccountName: secure
+      containers:
+      - name: backend
+        image: ghcr.io/stefanprodan/podinfo:5.0.3
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 9898
+          protocol: TCP
+        - name: http-metrics
+          containerPort: 9797
+          protocol: TCP
+        - name: grpc
+          containerPort: 9999
+          protocol: TCP
+        command:
+        - ./podinfo
+        - --port=9898
+        - --port-metrics=9797
+        - --grpc-port=9999
+        - --grpc-service-name=backend
+        - --level=info
+        env:
+        - name: PODINFO_UI_COLOR
+          value: "#34577c"
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 32Mi

--- a/deploy/secure/backend/hpa.yaml
+++ b/deploy/secure/backend/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend
+  namespace: secure
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 99

--- a/deploy/secure/backend/service.yaml
+++ b/deploy/secure/backend/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: secure
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+    - port: 9999
+      targetPort: grpc
+      protocol: TCP
+      name: grpc

--- a/deploy/secure/common/cluster-issuer.yaml
+++ b/deploy/secure/common/cluster-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed
+spec:
+  selfSigned: {}

--- a/deploy/secure/common/namespace.yaml
+++ b/deploy/secure/common/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secure

--- a/deploy/secure/common/reconciler-rbac.yaml
+++ b/deploy/secure/common/reconciler-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: reconciler
+  namespace: secure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: reconciler
+  namespace: secure
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: reconciler
+  namespace: secure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: reconciler
+subjects:
+  - kind: ServiceAccount
+    name: reconciler
+    namespace: secure

--- a/deploy/secure/common/service-account.yaml
+++ b/deploy/secure/common/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secure
+  namespace: secure

--- a/deploy/secure/frontend/certificate.yaml
+++ b/deploy/secure/frontend/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: podinfo-frontend
+  namespace: secure
+spec:
+  dnsNames:
+    - frontend
+    - frontend.secure
+    - frontend.secure.cluster.local
+    - localhost
+  secretName: podinfo-frontend-tls
+  issuerRef:
+    name: self-signed
+    kind: ClusterIssuer

--- a/deploy/secure/frontend/deployment.yaml
+++ b/deploy/secure/frontend/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: secure
+spec:
+  minReadySeconds: 3
+  revisionHistoryLimit: 5
+  progressDeadlineSeconds: 60
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9797"
+      labels:
+        app: frontend
+    spec:
+      serviceAccountName: secure
+      volumes:
+      - name: tls
+        secret:
+          secretName: podinfo-frontend-tls
+      containers:
+      - name: frontend
+        image: deavon/podinfo:secure-port
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
+          allowPrivilegeEscalation: true
+        ports:
+        - name: http
+          containerPort: 9898
+          protocol: TCP
+          hostPort: 80
+        - name: https
+          containerPort: 9899
+          protocol: TCP
+          hostPort: 443
+        - name: http-metrics
+          containerPort: 9797
+          protocol: TCP
+        - name: grpc
+          containerPort: 9999
+          protocol: TCP
+        volumeMounts:
+        - name: tls
+          mountPath: /data/cert
+          readOnly: true
+        command:
+        - ./podinfo
+        - --port=9898
+        - --secure-port=9899
+        - --port-metrics=9797
+        - --level=info
+        - --cert-path=/data/cert
+        - --backend-url=http://backend:9898/echo
+        env:
+        - name: PODINFO_UI_COLOR
+          value: "#34577c"
+        livenessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - podcli
+            - check
+            - http
+            - localhost:9898/readyz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 32Mi

--- a/deploy/secure/frontend/hpa.yaml
+++ b/deploy/secure/frontend/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend
+  namespace: secure
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 99

--- a/deploy/secure/frontend/service.yaml
+++ b/deploy/secure/frontend/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: secure
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https


### PR DESCRIPTION
* add `secure-port` argument to podinfo
* add `cert-path` argument to podinfo
* add http server for secure port
* normalise http/https server start
* add manifests for example secure-port implementation (relies on cert-manager)
* add script to create a cluster via kind to test podinfo locally (with support for self-signed certs)

Closes: #105 