### PR TITLE
feat(charts): add tls support to helm chart

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,8 +21,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
       - name: Build container image
         run: |
-          GIT_COMMIT=$(git rev-list -1 HEAD) && \
-          docker build -t test/podinfo:latest --build-arg "REVISION=${GIT_COMMIT}" .
+          ./hack/build.sh
           kind load docker-image test/podinfo:latest
       - name: Setup Helm
         uses: ./.github/actions/helm
@@ -30,20 +29,11 @@ jobs:
           helm-version: ${{ matrix.helm-version }}
       - name: Install Tiller
         if: ${{ startsWith(matrix.helm-version, '2') }}
-        run: |
-          kubectl --namespace kube-system create sa tiller
-          kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-          helm init --service-account tiller --upgrade --wait
+        run: ./hack/tiller.sh
       - name: Deploy
-        run: |
-          helm upgrade -i podinfo ./charts/podinfo \
-          --set image.repository=test/podinfo \
-          --set image.tag=latest \
-          --namespace=default
+        run: ./hack/deploy.sh
       - name: Run integration tests
-        run: |
-          kubectl rollout status deployment/podinfo --timeout=1m
-          helm test podinfo
+        run: ./hack/test.sh
       - name: Debug failure
         if: failure()
         run: |

--- a/charts/podinfo/templates/_helpers.tpl
+++ b/charts/podinfo/templates/_helpers.tpl
@@ -59,3 +59,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the tls secret for secure port
+*/}}
+{{- define "podinfo.tlsSecretName" -}}
+{{- $fullname := include "podinfo.fullname" . -}}
+{{- default (printf "%s-tls" $fullname) .Values.tls.secretName }}
+{{- end }}

--- a/charts/podinfo/templates/certificate.yaml
+++ b/charts/podinfo/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.certificate.create -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "podinfo.fullname" . }}
+  labels:
+    {{- include "podinfo.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  {{- range .Values.certificate.dnsNames }}
+    - {{ . | quote }}
+  {{- end }}
+  secretName: {{ template "podinfo.tlsSecretName" . }}
+  issuerRef:
+  {{- .Values.certificate.issuerRef | toYaml | trimSuffix "\n" | nindent 4 }}
+{{- end }}

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
               {{- end }}
             {{- if .Values.tls.enabled }}
             - name: https
-              containerPort: {{ .Values.tls.port | default 98899 }}
+              containerPort: {{ .Values.tls.port | default 9899 }}
               protocol: TCP
               {{- if .Values.tls.hostPort }}
               hostPort: {{ .Values.tls.hostPort }}

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -34,9 +34,24 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if (or .Values.service.hostPort .Values.tls.hostPort) }}
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          {{- end }}
           command:
             - ./podinfo
             - --port={{ .Values.service.httpPort | default 9898 }}
+            {{- if .Values.tls.enabled }}
+            - --secure-port={{ .Values.tls.port }}
+            {{- end }}
+            {{- if .Values.tls.certPath }}
+            - --cert-path={{ .Values.tls.certPath }}
+            {{- end }}
             {{- if .Values.service.metricsPort }}
             - --port-metrics={{ .Values.service.metricsPort }}
             {{- end }}
@@ -87,6 +102,17 @@ spec:
             - name: http
               containerPort: {{ .Values.service.httpPort | default 9898 }}
               protocol: TCP
+              {{- if .Values.service.hostPort }}
+              hostPort: {{ .Values.service.hostPort }}
+              {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: https
+              containerPort: {{ .Values.tls.port | default 98899 }}
+              protocol: TCP
+              {{- if .Values.tls.hostPort }}
+              hostPort: {{ .Values.tls.hostPort }}
+              {{- end }}
+            {{- end }}
             {{- if .Values.service.metricsPort }}
             - name: http-metrics
               containerPort: {{ .Values.service.metricsPort }}
@@ -118,6 +144,11 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data
+          {{- if .Values.tls.enabled }}
+          - name: tls
+            mountPath: {{ .Values.tls.certPath | default "/data/cert" }}
+            readOnly: true
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -135,3 +166,8 @@ spec:
       volumes:
       - name: data
         emptyDir: {}
+      {{- if .Values.tls.enabled }}
+      - name: tls
+        secret:
+          secretName: {{ template "podinfo.tlsSecretName" . }}
+      {{- end }}

--- a/charts/podinfo/templates/service.yaml
+++ b/charts/podinfo/templates/service.yaml
@@ -15,6 +15,12 @@ spec:
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- if .Values.tls.enabled }}
+    - port: {{ .Values.tls.port | default 9899 }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    {{- end }}
     {{- if .Values.service.grpcPort }}
     - port: {{ .Values.service.grpcPort }}
       targetPort: grpc

--- a/charts/podinfo/templates/tests/tls.yaml
+++ b/charts/podinfo/templates/tests/tls.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.tls.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "podinfo.fullname" . }}-tls-test-{{ randAlphaNum 5 | lower }}
+  labels:
+    {{- include "podinfo.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    sidecar.istio.io/inject: "false"
+    linkerd.io/inject: disabled
+    appmesh.k8s.aws/sidecarInjectorWebhook: disabled
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl:7.69.0
+      command:
+        - sh
+        - -c
+        - |
+          curl -sk ${PODINFO_SVC}/api/info | grep version
+      env:
+        - name: PODINFO_SVC
+          value: "https://{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.tls.port }}"
+  restartPolicy: Never
+{{- end }}

--- a/charts/podinfo/values-secure.yaml
+++ b/charts/podinfo/values-secure.yaml
@@ -42,7 +42,7 @@ service:
 
 # enable tls on the podinfo service
 tls:
-  enabled: false
+  enabled: true
   # the name of the secret used to mount the certificate key pair
   secretName:
   # the path where the certificate key pair will be mounted
@@ -56,7 +56,7 @@ tls:
 
 # create a certificate manager certificate
 certificate:
-  create: false
+  create: true
   # the issuer used to issue the certificate
   issuerRef:
     kind: ClusterIssuer

--- a/deploy/kind.sh
+++ b/deploy/kind.sh
@@ -6,34 +6,18 @@ kind create cluster --config=kind.yaml
 # add certificate manager
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.yaml
 
-# wait for cert manager webhook
-kubectl wait --namespace cert-manager \
-  --for=condition=available deployment \
-  --selector=app=webhook \
-  --timeout=120s
+# wait for cert manager
+kubectl rollout status --namespace cert-manager deployment/cert-manager --timeout=2m
+kubectl rollout status --namespace cert-manager deployment/cert-manager-webhook --timeout=2m
+kubectl rollout status --namespace cert-manager deployment/cert-manager-cainjector --timeout=2m
 
-# wait for the injector
-kubectl wait --namespace cert-manager \
-  --for=condition=available deployment \
-  --selector=app=cainjector \
-  --timeout=120s
-
-# wait for the cert manager
-kubectl wait --namespace cert-manager \
-  --for=condition=available deployment \
-  --selector=app=cert-manager \
-  --timeout=120s
-
-# apply the secure webapp
+# # apply the secure webapp
 kubectl apply -f ./secure/common
 kubectl apply -f ./secure/backend
 kubectl apply -f ./secure/frontend
 
-# wait for the podinfo frontend to come up
-kubectl wait --namespace secure \
-  --for=condition=ready pod \
-  --selector=app=frontend \
-  --timeout=120s
+# # wait for the podinfo frontend to come up
+kubectl rollout status --namespace secure deployment/frontend --timeout=1m
 
 # curl the endpoints (responds with info due to header regexp on route handler)
 echo

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env sh
+
+set -e
+
+# build the docker file
+GIT_COMMIT=$(git rev-list -1 HEAD) && \
+DOCKER_BUILDKIT=1 docker build --tag test/podinfo --build-arg "REVISION=${GIT_COMMIT}" .

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env sh
+
+# add jetstack repository
+helm repo add jetstack https://charts.jetstack.io || true
+
+# install cert-manager
+helm upgrade --install cert-manager jetstack/cert-manager \
+    --set installCRDs=true \
+    --namespace default
+
+# wait for cert manager
+kubectl rollout status deployment/cert-manager --timeout=2m
+kubectl rollout status deployment/cert-manager-webhook --timeout=2m
+kubectl rollout status deployment/cert-manager-cainjector --timeout=2m
+
+# install self-signed certificate
+cat << 'EOF' | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed
+spec:
+  selfSigned: {}
+EOF
+
+# install podinfo with tls enabled
+helm upgrade --install podinfo ./charts/podinfo \
+    --set image.repository=test/podinfo \
+    --set image.tag=latest \
+    --set tls.enabled=true \
+    --set certificate.create=true \
+    --namespace=default

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env sh
+
+set -e
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+
+# run the build
+$SCRIPT_DIR/build.sh
+
+# create the kind cluster
+kind create cluster || true
+
+# load the docker image
+kind load docker-image test/podinfo:latest
+
+# run the deploy
+$SCRIPT_DIR/deploy.sh
+
+# run the tests
+$SCRIPT_DIR/test.sh

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,0 +1,9 @@
+#1 /usr/bin/env sh
+
+set -e
+
+# wait for podinfo
+kubectl rollout status deployment/podinfo --timeout=3m
+
+# test podinfo
+helm test podinfo

--- a/hack/tiller.sh
+++ b/hack/tiller.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env sh
+
+set -e
+
+kubectl --namespace kube-system create sa tiller
+kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+helm init --service-account tiller --upgrade --wait


### PR DESCRIPTION
* add tls variable block to configure service and pod with secure-port
* add ability to create cert-manager certificate
* add support for host ports (both http and https)
* add helm test for tls port
* add example values for secure-port deployment
  - this assumes certificate manager is deployed to the cluster
* pull out script blocks into `hack` path
* update e2e workflow to use scripts in `hack`
* install cert manager and self-signed cluster issuer in e2e
* deploy podinfo with secure port and certificate enabled
* add `hack/e2e.sh` script, which can be used to execute the github
  workflow locally

Closes: #107