### PR TITLE
Add quoting support in ingress to allow wildcard domain

### DIFF
--- a/charts/podinfo/templates/ingress.yaml
+++ b/charts/podinfo/templates/ingress.yaml
@@ -17,14 +17,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}


### PR DESCRIPTION
YAML requires asterisk to be quoted.  
If we want to use wildcard host in the ingress so we put in values.yaml something like
```
ingress:
  tls:
    - secretName: my-secret-tls
      hosts:
        - '*.example.com'
```
then Helm removes the quote mark before putting the hosts value in the ingress, so the ingress will have this unquoted and will give error:
```
Error: YAML parse error on podinfo/templates/ingress.yaml: error converting YAML to JSON: yaml: line 21: did not find expected alphabetic or numeric character
```

See same issue : <https://github.com/helm/helm/issues/3936>.
and this PR that fixes it in Helm code: <https://github.com/helm/helm/pull/3956>.

This fix applies the same to podinfo.