### PR TITLE
Fix adduser param to actually use 'app' group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG REVISION
 LABEL maintainer="stefanprodan"
 
 RUN addgroup -S app \
-    && adduser -S -g app app \
+    && adduser -S -G app app \
     && apk --no-cache add \
     ca-certificates curl netcat-openbsd
 


### PR DESCRIPTION
This PR closes #116:

```
$ docker container run -ti --rm ghcr.io/stefanprodan/podinfo:5.1.2 id app
uid=100(app) gid=65533(nogroup) groups=65533(nogroup),65533(nogroup)
```

fixed `Dockerfile`:
```
$ docker container run -ti --rm podinfo:correct id app
uid=100(app) gid=101(app) groups=101(app),101(app)
```

