### PR TITLE
chart: Fix ServiceMonitor matchLabels for service

### DIFF
--- a/charts/podinfo/templates/servicemonitor.yaml
+++ b/charts/podinfo/templates/servicemonitor.yaml
@@ -12,5 +12,5 @@ spec:
       interval: {{ .Values.serviceMonitor.interval }}
   selector:
     matchLabels:
-      app: {{ template "podinfo.fullname" . }}
+      {{- include "podinfo.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Match labels for service monitor should be `app.kubernetes.io/name=podinfo`, using the `podinfo.selectorLabels` helper for future changes.
