### PR TITLE
fix(chart): ensure podinfo container runs on clusters that require running as non-root

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if (or .Values.service.hostPort .Values.tls.hostPort) }}
           securityContext:
+            runAsUser: 100
+            runAsGroup: 101
+          {{- if (or .Values.service.hostPort .Values.tls.hostPort) }}
             allowPrivilegeEscalation: true
             capabilities:
               drop:


### PR DESCRIPTION
Clusters that enforce running containers as non-root currently don't run podinfo.

```
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Pulled     1s (x3 over 15s)  kubelet            Container image "ghcr.io/stefanprodan/podinfo:5.1.4" already present on machine
  Warning  Failed     1s (x3 over 15s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (app), cannot verify user is non-root
```

This PR explicitly passes the UID and GID the container will run as.