### PR TITLE
fix(chart): ensure that the servicemonitor only selects its own namespace

### DIFF
--- a/charts/podinfo/templates/servicemonitor.yaml
+++ b/charts/podinfo/templates/servicemonitor.yaml
@@ -10,6 +10,9 @@ spec:
     - path: /metrics
       port: http
       interval: {{ .Values.serviceMonitor.interval }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "podinfo.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
As a matter of best-practice, the ServiceMonitor should only select its own namespace.