### PR TITLE
chart: Fix Redis backend url

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             {{- if .Values.cache }}
             - --cache-server={{ .Values.cache }}
             {{- else if .Values.redis.enabled }}
-            - --cache-server={{ template "podinfo.fullname" . }}:6379
+            - --cache-server={{ template "podinfo.fullname" . }}-redis:6379
             {{- end }}
             - --level={{ .Values.logLevel }}
             - --random-delay={{ .Values.faults.delay }}


### PR DESCRIPTION
The connection information for redis does not match the service entry.
