### PR TITLE
Add option to bind service to specific host

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
           command:
             - ./podinfo
             - --port={{ .Values.service.httpPort | default 9898 }}
+            {{- if .Values.host }}
+            - --host={{ .Values.host }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - --secure-port={{ .Values.tls.port }}
             {{- end }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -2,6 +2,7 @@
 
 replicaCount: 1
 logLevel: info
+host: #0.0.0.0
 backend: #http://backend-podinfo:9898/echo
 backends: []
 

--- a/cmd/podinfo/main.go
+++ b/cmd/podinfo/main.go
@@ -23,7 +23,8 @@ import (
 func main() {
 	// flags definition
 	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
-	fs.Int("port", 9898, "HTTP port")
+	fs.String("host", "", "Host to bind service to")
+	fs.Int("port", 9898, "HTTP port to bind service to")
 	fs.Int("secure-port", 0, "HTTPS port")
 	fs.Int("port-metrics", 0, "metrics port")
 	fs.Int("grpc-port", 0, "gRPC port")
@@ -89,8 +90,8 @@ func main() {
 		if readErr := viper.ReadInConfig(); readErr != nil {
 			fmt.Printf("Error reading config file, %v\n", readErr)
 		}
-	}else{
-		fmt.Printf("Error to open config file, %v\n",fileErr)
+	} else {
+		fmt.Printf("Error to open config file, %v\n", fileErr)
 	}
 
 	// configure logging

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -56,6 +56,7 @@ type Config struct {
 	DataPath                  string        `mapstructure:"data-path"`
 	ConfigPath                string        `mapstructure:"config-path"`
 	CertPath                  string        `mapstructure:"cert-path"`
+	Host                      string        `mapstructure:"host"`
 	Port                      string        `mapstructure:"port"`
 	SecurePort                string        `mapstructure:"secure-port"`
 	PortMetrics               int           `mapstructure:"port-metrics"`
@@ -239,7 +240,7 @@ func (s *Server) startServer() *http.Server {
 	}
 
 	srv := &http.Server{
-		Addr:         ":" + s.config.Port,
+		Addr:         s.config.Host + ":" + s.config.Port,
 		WriteTimeout: s.config.HttpServerTimeout,
 		ReadTimeout:  s.config.HttpServerTimeout,
 		IdleTimeout:  2 * s.config.HttpServerTimeout,
@@ -248,6 +249,7 @@ func (s *Server) startServer() *http.Server {
 
 	// start the server in the background
 	go func() {
+		s.logger.Info("Starting HTTP Server.", zap.String("addr", srv.Addr))
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 			s.logger.Fatal("HTTP server crashed", zap.Error(err))
 		}
@@ -267,7 +269,7 @@ func (s *Server) startSecureServer() *http.Server {
 	}
 
 	srv := &http.Server{
-		Addr:         ":" + s.config.SecurePort,
+		Addr:         s.config.Host + ":" + s.config.SecurePort,
 		WriteTimeout: s.config.HttpServerTimeout,
 		ReadTimeout:  s.config.HttpServerTimeout,
 		IdleTimeout:  2 * s.config.HttpServerTimeout,
@@ -279,6 +281,7 @@ func (s *Server) startSecureServer() *http.Server {
 
 	// start the server in the background
 	go func() {
+		s.logger.Info("Starting HTTPS Server.", zap.String("addr", srv.Addr))
 		if err := srv.ListenAndServeTLS(cert, key); err != http.ErrServerClosed {
 			s.logger.Fatal("HTTPS server crashed", zap.Error(err))
 		}


### PR DESCRIPTION
Useful when demonstrating service mesh functionality as by binding to localhost `--host=127.0.0.1` one can show how traffic needs to be routed via a sidecar proxy. 

Note: Haven't updated any version numbers (app or chart) - happy to do so if needed.