### PR TITLE
Using path = /* fails with nginx ingress

### DIFF
--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -103,7 +103,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /*
+  path: /
   hosts: []
   #  - podinfo.local
   tls: []


### PR DESCRIPTION
I'm not sure if something has changed, but the default value of "/*" in the ingress.path has the app return 404 when using an ingress-nginx chart

```
➜  helm ls -n ingress-basic
NAME         	NAMESPACE    	REVISION	UPDATED                             	STATUS  	CHART               	APP VERSION
nginx-ingress	ingress-basic	1       	2021-04-16 11:57:39.990536 -0500 CDT	deployed	ingress-nginx-3.29.0	0.45.0
➜  helm upgrade --install --wait podinfo podinfo/podinfo --set ui.message=podinfo-ingress --set ingress.enabled=true --set "ingress.hosts[0]=podinfo.20.94.144.87.nip.io"
Release "podinfo" has been upgraded. Happy Helming!
NAME: podinfo
LAST DEPLOYED: Fri Apr 16 12:41:02 2021
NAMESPACE: frontdoor
STATUS: deployed
REVISION: 5
NOTES:
1. Get the application URL by running these commands:
  http://podinfo.20.94.144.87.nip.io/*    
➜  curl http://podinfo.20.94.144.87.nip.io/
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
➜  helm upgrade --install --wait podinfo podinfo/podinfo --set ui.message=podinfo-ingress --set ingress.enabled=true --set "ingress.hosts[0]=podinfo.20.94.144.87.nip.io" --set ingress.path='/'
Release "podinfo" has been upgraded. Happy Helming!
NAME: podinfo
LAST DEPLOYED: Fri Apr 16 12:41:21 2021
NAMESPACE: frontdoor
STATUS: deployed
REVISION: 6
NOTES:
1. Get the application URL by running these commands:
  http://podinfo.20.94.144.87.nip.io/    
➜  curl http://podinfo.20.94.144.87.nip.io/
{
  "hostname": "podinfo-667dfc777d-cnffh",
  "version": "5.2.0",
  "revision": "",
  "color": "#34577c",
  "logo": "https://raw.githubusercontent.com/stefanprodan/podinfo/gh-pages/cuddle_clap.gif",
  "message": "podinfo-ingress",
  "goos": "linux",
  "goarch": "amd64",
  "runtime": "go1.16.2",
  "num_goroutine": "8",
  "num_cpu": "2"
}%
```