### PR TITLE
added additional labels to servicemonitor template

### DIFF
--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 5.2.0
+version: 5.2.1
 appVersion: 5.2.0
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 5.2.1
+version: 5.2.0
 appVersion: 5.2.0
 name: podinfo
 engine: gotpl

--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -1,6 +1,6 @@
 # Podinfo
 
-Podinfo is a tiny web application made with Go 
+Podinfo is a tiny web application made with Go
 that showcases best practices of running microservices in Kubernetes.
 
 Podinfo is used by CNCF projects like [Flux](https://github.com/fluxcd/flux2)
@@ -14,7 +14,7 @@ To install the chart with the release name `my-release`:
 ```console
 $ helm repo add podinfo https://stefanprodan.github.io/podinfo
 
-$ helm upgrade -i my-release podinfo/podinfo 
+$ helm upgrade -i my-release podinfo/podinfo
 ```
 
 The command deploys podinfo on the Kubernetes cluster in the default namespace.
@@ -74,6 +74,7 @@ Parameter | Default | Description
 `linkerd.profile.enabled` | `false` | Create Linkerd service profile
 `serviceMonitor.enabled` | `false` | Whether a Prometheus Operator service monitor should be created
 `serviceMonitor.interval` | `15s` | Prometheus scraping interval
+`serviceMonitor.additionalLabels` | `{}` | Add additional labels to the service monitor |
 `ingress.enabled` | `false` | Enables Ingress
 `ingress.annotations` | `{}` | Ingress annotations
 `ingress.path` | `/*` | Ingress path

--- a/charts/podinfo/templates/servicemonitor.yaml
+++ b/charts/podinfo/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "podinfo.fullname" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - path: /metrics

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -116,6 +116,7 @@ linkerd:
 serviceMonitor:
   enabled: false
   interval: 15s
+  additionalLabels: {}
 
 resources:
   limits:

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -120,6 +120,7 @@ linkerd:
 serviceMonitor:
   enabled: false
   interval: 15s
+  additionalLabels: {}
 
 resources:
   limits:


### PR DESCRIPTION
This PR add the option to add additional labels to the service monitor within the helm chart.