### PR TITLE
chart: Upgrade Ingress to networking.k8s.io/v1 and add ingressClassName

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,13 +11,15 @@ jobs:
     strategy:
       matrix:
         helm-version:
-          - 3.5.3
+          - 3.6.0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Kubernetes
         uses: engineerd/setup-kind@v0.5.0
+        with:
+          image: kindest/node:v1.19.11
       - name: Build container image
         run: |
           ./test/build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,15 @@ jobs:
       - name: Validate Helm chart
         uses: stefanprodan/kube-tools@v1
         with:
+          kubectl: 1.19.11
+          helm: 2.17.0
+          helmv3: 3.6.0
           command: |
-            helmv3 template ./charts/podinfo | kubeval --strict
+            helmv3 template ./charts/podinfo | kubeval --strict --kubernetes-version 1.19.11 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
       - name: Validate kustomization
         uses: stefanprodan/kube-tools@v1
         with:
+          kubectl: 1.19.11
           command: |
-            kustomize build ./kustomize | kubeval --strict
+            kustomize build ./kustomize | kubeval --strict --kubernetes-version 1.19.11 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
             kustomize build ./kustomize | conftest test -p .github/policy -

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 5.2.1
+version: 6.0.0
 appVersion: 5.2.1
 name: podinfo
 engine: gotpl
@@ -10,3 +10,4 @@ maintainers:
   name: stefanprodan
 sources:
 - https://github.com/stefanprodan/podinfo
+kubeVersion: ">=1.19.0-0"

--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -76,8 +76,8 @@ Parameter | Default | Description
 `serviceMonitor.interval` | `15s` | Prometheus scraping interval
 `serviceMonitor.additionalLabels` | `{}` | Add additional labels to the service monitor |
 `ingress.enabled` | `false` | Enables Ingress
+`ingress.className ` | `""` | Use ingressClassName
 `ingress.annotations` | `{}` | Ingress annotations
-`ingress.path` | `/*` | Ingress path
 `ingress.hosts` | `[]` | Ingress accepted hosts
 `ingress.tls` | `[]` | Ingress TLS configuration
 `resources.requests.cpu` | `1m` | Pod CPU request

--- a/charts/podinfo/templates/ingress.yaml
+++ b/charts/podinfo/templates/ingress.yaml
@@ -1,43 +1,41 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "podinfo.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+{{- $svcPort := .Values.service.externalPort -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
-{{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
-spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
-  {{- if not .Values.ingress.hosts }}
-    - http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -97,12 +97,15 @@ securityContext: {}
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /*
-  hosts: []
-  #  - podinfo.local
+  hosts:
+    - host: podinfo.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -101,12 +101,15 @@ securityContext: {}
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  path: /*
-  hosts: []
-  #  - podinfo.local
+  hosts:
+    - host: podinfo.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

* uses new ingress template which adds option to set ingressClassName and pathtype (disabled by default) introduced by k8s 1.18.x -> https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
* set kubeversion to 1.19 in chart.yaml

ci update:
* updates kind to use 1.19 images
* updates helm to 3.6.0
* updates kubeval to use another json schem location with more recent content