### PR TITLE
chart: Allow nodePort override for LoadBalancer service type

### DIFF
--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -62,6 +62,7 @@ Parameter | Default | Description
 `service.grpcPort` | `9999` | ClusterIP gPRC port
 `service.grpcService` | `podinfo` | gPRC service name
 `service.nodePort` | `31198` | NodePort for the HTTP endpoint
+`service.lbNodePort` | `None` | NodePort override for LoadBalancer service type
 `h2c.enabled` | `false` | Allow upgrading to h2c (non-TLS version of HTTP/2)
 `hpa.enabled` | `false` | Enables the Kubernetes HPA
 `hpa.maxReplicas` | `10` | Maximum amount of pods

--- a/charts/podinfo/templates/service.yaml
+++ b/charts/podinfo/templates/service.yaml
@@ -16,8 +16,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      {{- if (and (eq .Values.service.type "NodePort") .Values.service.nodePort) }}
       nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      {{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.lbNodePort) }}
+      nodePort: {{ .Values.service.lbNodePort }}
       {{- end }}
     {{- if .Values.tls.enabled }}
     - port: {{ .Values.tls.port | default 9899 }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -40,6 +40,8 @@ service:
   # NOTE: requires privileged container with NET_BIND_SERVICE capability -- this is useful for testing
   # in local clusters such as kind without port forwarding
   hostPort:
+  # NodePort override for LoadBalancer service type
+  lbNodePort:
 
 # enable h2c protocol (non-TLS version of HTTP/2)
 h2c:


### PR DESCRIPTION
Allows setting `ports.nodePort` in `Service` spec for `LoadBalancer` service type in addition to `NodePort` service type.
According to https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec:

> ports.nodePort (int32)
> The port on each node on which this service is exposed when type is NodePort or LoadBalancer.

Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>