### PR TITLE
Add store metric (Custom Metric Example) and prometheusrule (Alertmanager Example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Web API:
 * `DELETE /cache/{key}` deletes the key from Redis if exists
 * `POST /store` writes the posted content to disk at /data/hash and returns the SHA1 hash of the content
 * `GET /store/{hash}` returns the content of the file /data/hash if exists
+* `DELETE /store/{hash}` deletes the file /data/hash if exists
 * `GET /ws/echo` echos content via websockets `podcli ws ws://localhost:9898/ws/echo`
 * `GET /chunked/{seconds}` uses `transfer-encoding` type `chunked` to give a partial response and then waits for the specified period
 * `GET /swagger.json` returns the API Swagger docs, used for Linkerd service profiling and Gloo routes discovery

--- a/charts/podinfo/templates/prometheusrule.yaml
+++ b/charts/podinfo/templates/prometheusrule.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "podinfo.fullname" . }}
+  labels:
+    {{- include "podinfo.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+  - name: ./{{ template "podinfo.fullname" . }}.rules
+    rules:
+    - alert: TooManyStoredFiles
+      expr: stored_files > 5
+{{- end }}

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -121,6 +121,11 @@ serviceMonitor:
   interval: 15s
   additionalLabels: {}
 
+# create Prometheus Operator rule
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+
 resources:
   limits:
     memory: 256Mi

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -125,6 +125,11 @@ serviceMonitor:
   interval: 15s
   additionalLabels: {}
 
+# create Prometheus Operator rule
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+
 resources:
   limits:
   requests:

--- a/pkg/api/docs/docs.go
+++ b/pkg/api/docs/docs.go
@@ -419,6 +419,24 @@ var doc = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "deletes the posted content to disk at /data/hash",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HTTP API"
+                ],
+                "summary": "Delete file",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.MapResponse"
+                        }
+                    }
+                }
             }
         },
         "/store/{hash}": {

--- a/pkg/api/docs/swagger.json
+++ b/pkg/api/docs/swagger.json
@@ -408,6 +408,24 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "deletes the posted content to disk at /data/hash",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HTTP API"
+                ],
+                "summary": "Delete file",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.MapResponse"
+                        }
+                    }
+                }
             }
         },
         "/store/{hash}": {

--- a/pkg/api/docs/swagger.yaml
+++ b/pkg/api/docs/swagger.yaml
@@ -298,6 +298,18 @@ paths:
       tags:
       - HTTP API
   /store:
+    delete:
+      description: deletes the posted content to disk at /data/hash
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MapResponse'
+      summary: Delete file
+      tags:
+      - HTTP API
     post:
       consumes:
       - application/json

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -109,6 +109,7 @@ func (s *Server) registerHandlers() {
 	s.router.HandleFunc("/status/{code:[0-9]+}", s.statusHandler).Methods("GET", "POST", "PUT").Name("status")
 	s.router.HandleFunc("/store", s.storeWriteHandler).Methods("POST", "PUT")
 	s.router.HandleFunc("/store/{hash}", s.storeReadHandler).Methods("GET").Name("store")
+	s.router.HandleFunc("/store/{hash}", s.storeDeleteHandler).Methods("DELETE").Name("store")
 	s.router.HandleFunc("/cache/{key}", s.cacheWriteHandler).Methods("POST", "PUT")
 	s.router.HandleFunc("/cache/{key}", s.cacheDeleteHandler).Methods("DELETE")
 	s.router.HandleFunc("/cache/{key}", s.cacheReadHandler).Methods("GET").Name("cache")
@@ -133,7 +134,7 @@ func (s *Server) registerHandlers() {
 }
 
 func (s *Server) registerMiddlewares() {
-	prom := NewPrometheusMiddleware()
+	prom := NewPrometheusMiddleware(s)
 	s.router.Use(prom.Handler)
 	httpLogger := NewLoggingMiddleware(s.logger)
 	s.router.Use(httpLogger.Handler)

--- a/pkg/api/store.go
+++ b/pkg/api/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 
 	"github.com/gorilla/mux"
@@ -35,6 +36,24 @@ func (s *Server) storeWriteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.JSONResponseCode(w, r, map[string]string{"hash": hash}, http.StatusAccepted)
+}
+
+// Store godoc
+// @Summary Delete file
+// @Description deletes the posted content to disk at /data/hash
+// @Tags HTTP API
+// @Produce json
+// @Router /store [delete]
+// @Success 200 {object} api.MapResponse
+func (s *Server) storeDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	hash := mux.Vars(r)["hash"]
+	err := os.Remove(path.Join(s.config.DataPath, hash))
+	if err != nil {
+		s.logger.Warn("delete file failed", zap.Error(err), zap.String("file", path.Join(s.config.DataPath, hash)))
+		s.ErrorResponse(w, r, "delete file failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
 }
 
 // Store godoc


### PR DESCRIPTION
I have been using podinfo for some time for demos and local testing. Today I was doing some tests with Prometheus AlertManager and though if I could use something from podinfo to trigger them.
Even though there are some metrics available these are not easly maniputated to trigger on and off alerts on Prometheus AlertManager.
I researched a little bit on what I could use and decided to take on stored files since I could already incease this value on demand. Added new deleted endpoint so the value can be decreased.