### PR TITLE
Fix ingress URL in Helm chart NOTES.txt

### DIFF
--- a/charts/podinfo/templates/NOTES.txt
+++ b/charts/podinfo/templates/NOTES.txt
@@ -1,7 +1,9 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "podinfo.fullname" . }})


### PR DESCRIPTION
Fixes the notes that are printed when the Helm chart is installed with `ingress.enabled: true`.

Before:
```
1. Get the application URL by running these commands:
  https://map[host:podinfo.example.com paths:[map[path:/ pathType:ImplementationSpecific]]]
```

After the change:
```
1. Get the application URL by running these commands:
  https://podinfo.example.com/
```

The changed part is taken as-is from the output of the `helm create` command of Helm version 3.7.1.
Tested & working as expected.