### PR TITLE
adds method and path tags to request metric

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -35,7 +35,7 @@ func NewPrometheusMiddleware() *PrometheusMiddleware {
 			Name:      "requests_total",
 			Help:      "The total number of HTTP requests.",
 		},
-		[]string{"status"},
+		[]string{"method", "path", "status"},
 	)
 
 	prometheus.MustRegister(histogram)
@@ -65,7 +65,7 @@ func (p *PrometheusMiddleware) Handler(next http.Handler) http.Handler {
 			took   = time.Since(begin)
 		)
 		p.Histogram.WithLabelValues(r.Method, path, status).Observe(took.Seconds())
-		p.Counter.WithLabelValues(status).Inc()
+		p.Counter.WithLabelValues(r.Method, path, status).Inc()
 	})
 }
 


### PR DESCRIPTION
As mentioned on issue #153, some tags are missing on `requests_total` http metric, and can be easily captured. This 2 liner PR adds those tags.

# Details

Adds `method` and `path` as tags to `requests_total` metric.
