### PR TITLE
Add a way to customize liveness and readiness probes in helm chart

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -136,8 +136,13 @@ spec:
               - check
               - http
               - localhost:{{ .Values.service.httpPort | default 9898 }}/healthz
-            initialDelaySeconds: 1
-            timeoutSeconds: 5
+            {{- with .Values.probes.liveness }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 1 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 5 }}
+            failureThreshold: {{ .failureThreshold | default 3 }}
+            successThreshold: {{ .successThreshold | default 1 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            {{- end }}
           readinessProbe:
             exec:
               command:
@@ -145,8 +150,13 @@ spec:
               - check
               - http
               - localhost:{{ .Values.service.httpPort | default 9898 }}/readyz
-            initialDelaySeconds: 1
-            timeoutSeconds: 5
+            {{- with .Values.probes.readiness }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 1 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 5 }}
+            failureThreshold: {{ .failureThreshold | default 3 }}
+            successThreshold: {{ .successThreshold | default 1 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            {{- end }}
           volumeMounts:
           - name: data
             mountPath: /data

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -140,3 +140,18 @@ tolerations: []
 affinity: {}
 
 podAnnotations: {}
+
+# https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+probes:
+  readiness:
+    initialDelaySeconds: 1
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    periodSeconds: 10
+  liveness:
+    initialDelaySeconds: 1
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+    periodSeconds: 10


### PR DESCRIPTION
The reason for this change is that in my environment the http check takes around 5 seconds:

```bash
k exec -ti frontend-podinfo-79775fc847-c4xjm -- time podcli check http localhost:9898/healthz --timeout=7s
2022-10-03T15:37:19.472Z	INFO	podcli/check.go:131	check succeed	{"address": "http://localhost:9898/healthz", "status code": 200, "response size": "20 B"}
real	0m 5.03s
``` 

However, the 5 second is the limit and it can't be changed on the helm chart level so I can see the pod restarts. I am running multiple clusters on my mac and I am also behind corporate proxy so it's super slow. To avoid some ugly kubectl patches on the deployed version, I am opening this PR to be able to tweak the probes according the user's need.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>