### PR TITLE
Release v6.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w \
     -X github.com/stefanprodan/podinfo/pkg/version.REVISION=${REVISION}" \
     -a -o bin/podcli cmd/podcli/*
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG BUILD_DATE
 ARG VERSION

--- a/Dockerfile.xx
+++ b/Dockerfile.xx
@@ -28,7 +28,7 @@ RUN xx-go build -ldflags "-s -w \
     -X github.com/stefanprodan/podinfo/pkg/version.REVISION=${REVISION}" \
     -a -o bin/podcli cmd/podcli/*
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG BUILD_DATE
 ARG VERSION

--- a/charts/podinfo/Chart.yaml
+++ b/charts/podinfo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 6.2.3
-appVersion: 6.2.3
+version: 6.3.0
+appVersion: 6.3.0
 name: podinfo
 engine: gotpl
 description: Podinfo Helm chart for Kubernetes

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -8,7 +8,7 @@ backends: []
 
 image:
   repository: ghcr.io/stefanprodan/podinfo
-  tag: 6.2.3
+  tag: 6.3.0
   pullPolicy: IfNotPresent
 
 ui:
@@ -83,7 +83,7 @@ cache: ""
 redis:
   enabled: true
   repository: redis
-  tag: 6.0.8
+  tag: 7.0.7
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -8,7 +8,7 @@ backends: []
 
 image:
   repository: ghcr.io/stefanprodan/podinfo
-  tag: 6.2.3
+  tag: 6.3.0
   pullPolicy: IfNotPresent
 
 ui:
@@ -87,7 +87,7 @@ cache: ""
 redis:
   enabled: false
   repository: redis
-  tag: 6.0.8
+  tag: 7.0.7
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/cue/main.cue
+++ b/cue/main.cue
@@ -10,7 +10,7 @@ app: podinfo.#Application & {
 			name:      "podinfo"
 			namespace: "default"
 		}
-		image: tag: "6.2.3"
+		image: tag: "6.3.0"
 		resources: requests: {
 			cpu:    "100m"
 			memory: "16Mi"

--- a/deploy/bases/backend/deployment.yaml
+++ b/deploy/bases/backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: ghcr.io/stefanprodan/podinfo:6.2.3
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/bases/backend/hpa.yaml
+++ b/deploy/bases/backend/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: backend

--- a/deploy/bases/cache/deployment.yaml
+++ b/deploy/bases/cache/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:6.0.1
+          image: redis:7.0.7
           imagePullPolicy: IfNotPresent
           command:
             - redis-server

--- a/deploy/bases/frontend/deployment.yaml
+++ b/deploy/bases/frontend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: ghcr.io/stefanprodan/podinfo:6.2.3
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/bases/frontend/hpa.yaml
+++ b/deploy/bases/frontend/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: frontend

--- a/deploy/webapp/backend/deployment.yaml
+++ b/deploy/webapp/backend/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: webapp
       containers:
       - name: backend
-        image: ghcr.io/stefanprodan/podinfo:6.2.3
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy/webapp/frontend/deployment.yaml
+++ b/deploy/webapp/frontend/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: webapp
       containers:
       - name: frontend
-        image: ghcr.io/stefanprodan/podinfo:6.2.3
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.2.3
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "6.2.3"
+var VERSION = "6.3.0"
 var REVISION = "unknown"


### PR DESCRIPTION
**Breaking change**

To deploy Podinfo on Kubernetes with horizontal pod autoscaling the minimum required version is **Kubernetes v1.23**.