### PR TITLE
Update HPA to v2 in CUE definitions

### DIFF
--- a/cue/podinfo/hpa.cue
+++ b/cue/podinfo/hpa.cue
@@ -1,7 +1,7 @@
 package podinfo
 
 import (
-	autoscaling "k8s.io/api/autoscaling/v2beta2"
+	autoscaling "k8s.io/api/autoscaling/v2"
 )
 
 #hpaConfig: {
@@ -14,7 +14,7 @@ import (
 
 #HorizontalPodAutoscaler: autoscaling.#HorizontalPodAutoscaler & {
 	_config:    #Config
-	apiVersion: "autoscaling/v2beta2"
+	apiVersion: "autoscaling/v2"
 	kind:       "HorizontalPodAutoscaler"
 	metadata:   _config.meta
 	spec: {

--- a/cue/podinfo/servicemonitor.cue
+++ b/cue/podinfo/servicemonitor.cue
@@ -17,6 +17,6 @@ package podinfo
 			interval: _config.serviceMonitor.interval
 		}]
 		namespaceSelector: matchNames: [_config.meta.namespace]
-		selector: matchLabels:         _config.meta.labels
+		selector: matchLabels: _config.meta.labels
 	}
 }


### PR DESCRIPTION
Upgrade HPA to `autoscaling/v2` in CUE definitions 