### PR TITLE
build: Enable SBOM and SLSA Provenance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         helm-version:
-          - v3.10.3
+          - v3.11.0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,9 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\//}
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
-          echo ::set-output name=REVISION::${GITHUB_SHA}
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "REVISION=${GITHUB_SHA}" >> $GITHUB_OUTPUT
       - name: Generate images meta
         id: meta
         uses: docker/metadata-action@v4
@@ -66,6 +66,8 @@ jobs:
       - name: Publish multi-arch image
         uses: docker/build-push-action@v3
         with:
+          sbom: true
+          provenance: true
           push: true
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -96,7 +98,7 @@ jobs:
           cosign sign ghcr.io/stefanprodan/charts/podinfo:${{ steps.prep.outputs.VERSION }}
           cosign sign ghcr.io/stefanprodan/manifests/podinfo:${{ steps.prep.outputs.VERSION }}
       - name: Publish base image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Specifications:
 * End-to-End testing with Kubernetes Kind and Helm
 * Multi-arch container image with Docker buildx and Github Actions
 * Container image signing with Sigstore cosign
+* SBOMs and SLSA Provenance embedded in the container image
 * CVE scanning with Trivy
 
 Web API:


### PR DESCRIPTION
Recently buildkit has added support for generating [SBOMs](https://www.docker.com/blog/generate-sboms-with-buildkit/) and  [SLSA Provenance](https://github.com/moby/buildkit/blob/master/docs/attestations/attestation-storage.md). So we can attach the SBOM and Provenance to our container images using the Docker GH Action.