### PR TITLE
chart: Add optional startupProbe values 

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -129,6 +129,22 @@ spec:
               containerPort: {{ .Values.service.grpcPort }}
               protocol: TCP
             {{- end }}
+          {{- if .Values.probes.startup.enable }}
+          startupProbe:
+            exec:
+              command:
+              - podcli
+              - check
+              - http
+              - localhost:{{ .Values.service.httpPort | default 9898 }}/healthz
+            {{- with .Values.probes.startup }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 1 }}
+            timeoutSeconds: {{ .timeoutSeconds | default 5 }}
+            failureThreshold: {{ .failureThreshold | default 3 }}
+            successThreshold: {{ .successThreshold | default 1 }}
+            periodSeconds: {{ .periodSeconds | default 10 }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -155,3 +155,10 @@ probes:
     failureThreshold: 3
     successThreshold: 1
     periodSeconds: 10
+  startup:
+    enable: false
+    initialDelaySeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 20
+    successThreshold: 1
+    periodSeconds: 10


### PR DESCRIPTION

Add a `startupProbe` for the deployment. A flag is used to enable it (`probes.startup.enable`) and is false by default. 

The goal is to showcase how to deal with slow-starting applications (although this is not the case with podinfo). 