### PR TITLE
fix(hpa): reorder metrics

### DIFF
--- a/charts/podinfo/templates/hpa.yaml
+++ b/charts/podinfo/templates/hpa.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.replicaCount }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}
   metrics:
-  {{- if .Values.hpa.cpu }}
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.hpa.cpu }}
-  {{- end }}
   {{- if .Values.hpa.memory }}
   - type: Resource
     resource:
@@ -28,6 +20,14 @@ spec:
       target:
         type: AverageValue
         averageValue: {{ .Values.hpa.memory }}
+  {{- end }}
+  {{- if .Values.hpa.cpu }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.cpu }}
   {{- end }}
   {{- if .Values.hpa.requests }}
   - type: Pods


### PR DESCRIPTION
This change is required due to https://github.com/kubernetes/kubernetes/issues/74099. 
It would solve "always out-of-sync" issues.