### PR TITLE
Support publishing extra semver Docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,9 @@ jobs:
             docker.io/stefanprodan/podinfo
             ghcr.io/stefanprodan/podinfo
           tags: |
-            type=raw,value=${{ steps.prep.outputs.VERSION }}
-            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       - name: Publish multi-arch image
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
resolves #296

This change adds semver-style Docker tags {{major}} and {{major.minor}} for each release.

For example, when publishing release v3.2.1, this will push tags: 3.2.1, 3.2, 3, latest