### PR TITLE
Publish signed Timoni module to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,40 +6,43 @@ on:
       - '*'
 
 permissions:
-  contents: write # needed to write releases
-  id-token: write # needed for keyless signing
-  packages: write # needed for ghcr access
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to write releases
+      id-token: write # needed for keyless signing
+      packages: write # needed for ghcr access
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: sigstore/cosign-installer@v3
       - uses: fluxcd/flux2/action@main
+      - uses: stefanprodan/timoni/actions/setup@main
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Setup Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.3
+          version: v3.12.3
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
       - name: Setup Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -55,7 +58,7 @@ jobs:
           echo "REVISION=${GITHUB_SHA}" >> $GITHUB_OUTPUT
       - name: Generate images meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             docker.io/stefanprodan/podinfo
@@ -64,7 +67,7 @@ jobs:
             type=raw,value=${{ steps.prep.outputs.VERSION }}
             type=raw,value=latest
       - name: Publish multi-arch image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           sbom: true
           provenance: true
@@ -77,6 +80,15 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Publish Timoni module to GHCR
+        run: |
+          timoni mod push ./timoni/podinfo oci://ghcr.io/stefanprodan/modules/podinfo \
+          --sign cosign \
+          --version ${{ steps.prep.outputs.VERSION }} \
+          --source https://github.com/stefanprodan/podinfo  \
+          -a 'org.opencontainers.image.licenses=Apache-2.0' \
+          -a 'org.opencontainers.image.description=A timoni.sh module for deploying Podinfo.' \
+          -a 'org.opencontainers.image.documentation=https://github.com/stefanprodan/podinfo/blob/main/timoni/podinfo/README.md'
       - name: Publish Helm chart to GHCR
         run: |
           helm package charts/podinfo
@@ -98,7 +110,7 @@ jobs:
           cosign sign ghcr.io/stefanprodan/charts/podinfo:${{ steps.prep.outputs.VERSION }} --yes
           cosign sign ghcr.io/stefanprodan/manifests/podinfo:${{ steps.prep.outputs.VERSION }} --yes
       - name: Publish base image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
@@ -131,7 +143,7 @@ jobs:
           echo 'CHANGELOG' > /tmp/release.txt
           github-release-notes -org stefanprodan -repo podinfo -since-latest-release >> /tmp/release.txt
       - name: Publish release
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --release-notes=/tmp/release.txt --skip-validate


### PR DESCRIPTION
Push Timoni module to `oci://ghcr.io/stefanprodan/modules/podinfo` and sign the module with Cosign and GitHub OIDC.