### PR TITLE
feat(helm): add topologySpreadConstraints and PDB

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -203,3 +203,7 @@ spec:
         secret:
           secretName: {{ template "podinfo.tlsSecretName" . }}
       {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/podinfo/templates/pdb.yaml
+++ b/charts/podinfo/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.podDisruptionBudget (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "podinfo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "podinfo.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "podinfo.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.podDisruptionBudget | nindent 2 }}
+{{- end }}

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -142,6 +142,13 @@ affinity: {}
 
 podAnnotations: {}
 
+# https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+
+# Disruption budget will be configured only when the replicaCount is greater than 1
+podDisruptionBudget: {}
+#  maxUnavailable: 1
+
 # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 probes:
   readiness:


### PR DESCRIPTION
Hi there

First of all thank you very much for podinfo! It's such a nice app and I used it heavily in the last couple of days to check app availability during migration testing.

Duing so I found myself looking for config options to specify `topologySpreadConstraints` and `podDisruptionBudget` in the helm chart which I didn't found. They are often used to ensure maximum availability during upgrades.

So here they are ;)

Tests done: only helm template locally