### PR TITLE
ci: Use `GITHUB_OUTPUT` instead of set-output

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -3,7 +3,7 @@ name: cve-scan
 on:
   push:
     branches:
-      - 'master'
+      - "master"
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
         run: |
           IMAGE=test/podinfo:${GITHUB_SHA}
           docker build -t ${IMAGE} .
-          echo "::set-output name=image::$IMAGE"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
