### PR TITLE
Fixes /store endpoint with the kustomize deployment

### DIFF
--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -72,3 +72,9 @@ spec:
           requests:
             cpu: 100m
             memory: 64Mi
+        volumeMounts:
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
Added an emptyDir to the kustomzie deployment, otherwise the /store endpoint does not work for storing files.