### PR TITLE
Removed reference to localhost from swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ swagger:
 	go install github.com/swaggo/swag/cmd/swag@latest
 	go get github.com/swaggo/swag/gen@latest
 	go get github.com/swaggo/swag/cmd/swag@latest
-	cd pkg/api && $$(go env GOPATH)/bin/swag init -g server.go
+	cd pkg/api/http && $$(go env GOPATH)/bin/swag init -g server.go
 
 .PHONY: timoni-build
 timoni-build:

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -66,6 +67,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -73,6 +75,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/swaggo/files v0.0.0-20220610200504-28940afbdbfe // indirect
+	github.com/urfave/cli/v2 v2.3.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -85,4 +88,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -12,6 +13,8 @@ github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -99,11 +102,14 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
@@ -133,6 +139,8 @@ github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64
 github.com/swaggo/http-swagger v1.3.4/go.mod h1:9dAh0unqMBAlbp1uE2Uc2mQTxNMU/ha4UbucIg1MFkQ=
 github.com/swaggo/swag v1.16.3 h1:PnCYjPCah8FK4I26l2F/KQ4yz3sILcVUN3cTlBFA9Pg=
 github.com/swaggo/swag v1.16.3/go.mod h1:DImHIuOFXKpMFAQjcC7FG4m3Dg4+QuUgUzJmKjI/gRk=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.49.0 h1:h+c4WbSjBBc3j+IsxwB2mWvkm2nDh0SyGLa5Y5+V9cw=
 go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.49.0/go.mod h1:FObmJ0epY1FcwMR7aq7sRkrCfwwV3d0GBGFfyV5JUBg=
@@ -230,7 +238,10 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/pkg/api/http/chunked.go
+++ b/pkg/api/http/chunked.go
@@ -17,7 +17,7 @@ import (
 // @Produce json
 // @Param seconds path int true "seconds to wait for"
 // @Router /chunked/{seconds} [get]
-// @Success 200 {object} api.MapResponse
+// @Success 200 {object} http.MapResponse
 func (s *Server) chunkedHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "chunkedHandler")
 	defer span.End()

--- a/pkg/api/http/delay.go
+++ b/pkg/api/http/delay.go
@@ -51,7 +51,7 @@ func (m *RandomDelayMiddleware) Handler(next http.Handler) http.Handler {
 // @Produce json
 // @Param seconds path int true "seconds to wait for"
 // @Router /delay/{seconds} [get]
-// @Success 200 {object} api.MapResponse
+// @Success 200 {object} http.MapResponse
 func (s *Server) delayHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "delayHandler")
 	defer span.End()

--- a/pkg/api/http/docs/docs.go
+++ b/pkg/api/http/docs/docs.go
@@ -19,7 +19,6 @@ const docTemplate = `{
         },
         "version": "{{.Version}}"
     },
-    "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
         "/": {
@@ -59,7 +58,7 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -82,7 +81,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.RuntimeResponse"
+                            "$ref": "#/definitions/http.RuntimeResponse"
                         }
                     }
                 }
@@ -200,7 +199,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -232,7 +231,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -438,7 +437,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -461,7 +460,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -516,7 +515,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.TokenResponse"
+                            "$ref": "#/definitions/http.TokenResponse"
                         }
                     }
                 }
@@ -539,7 +538,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.TokenValidationResponse"
+                            "$ref": "#/definitions/http.TokenValidationResponse"
                         }
                     },
                     "401": {
@@ -565,7 +564,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -588,7 +587,7 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -596,13 +595,13 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "api.MapResponse": {
+        "http.MapResponse": {
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "api.RuntimeResponse": {
+        "http.RuntimeResponse": {
             "type": "object",
             "properties": {
                 "color": {
@@ -640,7 +639,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TokenResponse": {
+        "http.TokenResponse": {
             "type": "object",
             "properties": {
                 "expires_at": {
@@ -651,7 +650,7 @@ const docTemplate = `{
                 }
             }
         },
-        "api.TokenValidationResponse": {
+        "http.TokenValidationResponse": {
             "type": "object",
             "properties": {
                 "expires_at": {
@@ -668,7 +667,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "2.0",
-	Host:             "localhost:9898",
+	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{"http", "https"},
 	Title:            "Podinfo API",

--- a/pkg/api/http/docs/swagger.json
+++ b/pkg/api/http/docs/swagger.json
@@ -17,7 +17,6 @@
         },
         "version": "2.0"
     },
-    "host": "localhost:9898",
     "basePath": "/",
     "paths": {
         "/": {
@@ -57,7 +56,7 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -80,7 +79,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.RuntimeResponse"
+                            "$ref": "#/definitions/http.RuntimeResponse"
                         }
                     }
                 }
@@ -198,7 +197,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -230,7 +229,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -436,7 +435,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -459,7 +458,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -514,7 +513,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.TokenResponse"
+                            "$ref": "#/definitions/http.TokenResponse"
                         }
                     }
                 }
@@ -537,7 +536,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.TokenValidationResponse"
+                            "$ref": "#/definitions/http.TokenValidationResponse"
                         }
                     },
                     "401": {
@@ -563,7 +562,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -586,7 +585,7 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/api.MapResponse"
+                            "$ref": "#/definitions/http.MapResponse"
                         }
                     }
                 }
@@ -594,13 +593,13 @@
         }
     },
     "definitions": {
-        "api.MapResponse": {
+        "http.MapResponse": {
             "type": "object",
             "additionalProperties": {
                 "type": "string"
             }
         },
-        "api.RuntimeResponse": {
+        "http.RuntimeResponse": {
             "type": "object",
             "properties": {
                 "color": {
@@ -638,7 +637,7 @@
                 }
             }
         },
-        "api.TokenResponse": {
+        "http.TokenResponse": {
             "type": "object",
             "properties": {
                 "expires_at": {
@@ -649,7 +648,7 @@
                 }
             }
         },
-        "api.TokenValidationResponse": {
+        "http.TokenValidationResponse": {
             "type": "object",
             "properties": {
                 "expires_at": {

--- a/pkg/api/http/docs/swagger.yaml
+++ b/pkg/api/http/docs/swagger.yaml
@@ -1,10 +1,10 @@
 basePath: /
 definitions:
-  api.MapResponse:
+  http.MapResponse:
     additionalProperties:
       type: string
     type: object
-  api.RuntimeResponse:
+  http.RuntimeResponse:
     properties:
       color:
         type: string
@@ -29,21 +29,20 @@ definitions:
       version:
         type: string
     type: object
-  api.TokenResponse:
+  http.TokenResponse:
     properties:
       expires_at:
         type: string
       token:
         type: string
     type: object
-  api.TokenValidationResponse:
+  http.TokenValidationResponse:
     properties:
       expires_at:
         type: string
       token_name:
         type: string
     type: object
-host: localhost:9898
 info:
   contact:
     name: Source Code
@@ -79,7 +78,7 @@ paths:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Echo
       tags:
       - HTTP API
@@ -94,7 +93,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.RuntimeResponse'
+            $ref: '#/definitions/http.RuntimeResponse'
       summary: Runtime information
       tags:
       - HTTP API
@@ -173,7 +172,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Chunked transfer encoding
       tags:
       - HTTP API
@@ -194,7 +193,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Delay
       tags:
       - HTTP API
@@ -330,7 +329,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Status code
       tags:
       - HTTP API
@@ -346,7 +345,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Upload file
       tags:
       - HTTP API
@@ -382,7 +381,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.TokenResponse'
+            $ref: '#/definitions/http.TokenResponse'
       summary: Generate JWT token
       tags:
       - HTTP API
@@ -397,7 +396,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.TokenValidationResponse'
+            $ref: '#/definitions/http.TokenValidationResponse'
         "401":
           description: Unauthorized
           schema:
@@ -414,7 +413,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Version
       tags:
       - HTTP API
@@ -429,7 +428,7 @@ paths:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/api.MapResponse'
+            $ref: '#/definitions/http.MapResponse'
       summary: Echo over websockets
       tags:
       - HTTP API

--- a/pkg/api/http/echo.go
+++ b/pkg/api/http/echo.go
@@ -22,7 +22,7 @@ import (
 // @Accept json
 // @Produce json
 // @Router /api/echo [post]
-// @Success 202 {object} api.MapResponse
+// @Success 202 {object} http.MapResponse
 func (s *Server) echoHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, span := s.tracer.Start(r.Context(), "echoHandler")
 	defer span.End()

--- a/pkg/api/http/echows.go
+++ b/pkg/api/http/echows.go
@@ -18,7 +18,7 @@ var wsCon = websocket.Upgrader{}
 // @Accept json
 // @Produce json
 // @Router /ws/echo [post]
-// @Success 202 {object} api.MapResponse
+// @Success 202 {object} http.MapResponse
 // Test: go run ./cmd/podcli/* ws localhost:9898/ws/echo
 func (s *Server) echoWsHandler(w http.ResponseWriter, r *http.Request) {
 	c, err := wsCon.Upgrade(w, r, nil)

--- a/pkg/api/http/env.go
+++ b/pkg/api/http/env.go
@@ -13,7 +13,7 @@ import (
 // @Accept json
 // @Produce json
 // @Router /env [get]
-// @Success 200 {object} api.ArrayResponse
+// @Success 200 {object} http.ArrayResponse
 func (s *Server) envHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "envHandler")
 	defer span.End()

--- a/pkg/api/http/headers.go
+++ b/pkg/api/http/headers.go
@@ -11,7 +11,7 @@ import (
 // @Accept json
 // @Produce json
 // @Router /headers [get]
-// @Success 200 {object} api.ArrayResponse
+// @Success 200 {object} http.ArrayResponse
 func (s *Server) echoHeadersHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "echoHeadersHandler")
 	defer span.End()

--- a/pkg/api/http/info.go
+++ b/pkg/api/http/info.go
@@ -15,7 +15,7 @@ import (
 // @Tags HTTP API
 // @Accept json
 // @Produce json
-// @Success 200 {object} api.RuntimeResponse
+// @Success 200 {object} http.RuntimeResponse
 // @Router /api/info [get]
 func (s *Server) infoHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "infoHandler")

--- a/pkg/api/http/server.go
+++ b/pkg/api/http/server.go
@@ -35,7 +35,6 @@ import (
 // @license.name MIT License
 // @license.url https://github.com/stefanprodan/podinfo/blob/master/LICENSE
 
-// @host localhost:9898
 // @BasePath /
 // @schemes http https
 

--- a/pkg/api/http/status.go
+++ b/pkg/api/http/status.go
@@ -16,7 +16,7 @@ import (
 // @Produce json
 // @Param code path int true "status code to return"
 // @Router /status/{code} [get]
-// @Success 200 {object} api.MapResponse
+// @Success 200 {object} http.MapResponse
 func (s *Server) statusHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "statusHandler")
 	defer span.End()

--- a/pkg/api/http/store.go
+++ b/pkg/api/http/store.go
@@ -19,7 +19,7 @@ import (
 // @Accept json
 // @Produce json
 // @Router /store [post]
-// @Success 200 {object} api.MapResponse
+// @Success 200 {object} http.MapResponse
 func (s *Server) storeWriteHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "storeWriteHandler")
 	defer span.End()

--- a/pkg/api/http/token.go
+++ b/pkg/api/http/token.go
@@ -23,7 +23,7 @@ type jwtCustomClaims struct {
 // @Accept json
 // @Produce json
 // @Router /token [post]
-// @Success 200 {object} api.TokenResponse
+// @Success 200 {object} http.TokenResponse
 func (s *Server) tokenGenerateHandler(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(r.Context(), "tokenGenerateHandler")
 	defer span.End()
@@ -72,7 +72,7 @@ func (s *Server) tokenGenerateHandler(w http.ResponseWriter, r *http.Request) {
 // @Accept json
 // @Produce json
 // @Router /token/validate [post]
-// @Success 200 {object} api.TokenValidationResponse
+// @Success 200 {object} http.TokenValidationResponse
 // @Failure 401 {string} string "Unauthorized"
 // Get: JWT=$(curl -s -d 'test' localhost:9898/token | jq -r .token)
 // Post: curl -H "Authorization: Bearer ${JWT}" localhost:9898/token/validate

--- a/pkg/api/http/version.go
+++ b/pkg/api/http/version.go
@@ -12,7 +12,7 @@ import (
 // @Tags HTTP API
 // @Produce json
 // @Router /version [get]
-// @Success 200 {object} api.MapResponse
+// @Success 200 {object} http.MapResponse
 func (s *Server) versionHandler(w http.ResponseWriter, r *http.Request) {
 	result := map[string]string{
 		"version": version.VERSION,


### PR DESCRIPTION
Now it is possible to use the swagger webinterface running on a host other than localhost e.g. in docker or kubernetes.

Removed the @host line from pkg/api/server.go and
ran make swagger.

Fixes: #179 