### PR TITLE
feat(delay): add ability to delay with milliseconds

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -104,7 +104,7 @@ func (s *Server) registerHandlers() {
 	s.router.PathPrefix("/echo/").HandlerFunc(s.echoHandler)
 	s.router.HandleFunc("/env", s.envHandler).Methods("GET", "POST")
 	s.router.HandleFunc("/headers", s.echoHeadersHandler).Methods("GET", "POST")
-	s.router.HandleFunc("/delay/{wait:[0-9]+}", s.delayHandler).Methods("GET").Name("delay")
+	s.router.HandleFunc("/delay/{wait:[0-9]+(?:s|ms)?}", s.delayHandler).Methods("GET").Name("delay")
 	s.router.HandleFunc("/healthz", s.healthzHandler).Methods("GET")
 	s.router.HandleFunc("/readyz", s.readyzHandler).Methods("GET")
 	s.router.HandleFunc("/readyz/enable", s.enableReadyHandler).Methods("POST")


### PR DESCRIPTION
Hi ! 

I found myself in the need of having milliseconds delay (seconds can be too much to simulate application behavior). I suggest this change to allow milliseconds delay.

With this change, we could have: 
- `/delay/3` ==> current behavior: 3s delay
- `/delay/3s` ==> 3s delay
- `/delay/200ms` ==> 200ms delay

Tell me if any change is required !