### PR TITLE
feat(chart): allow input config and extraArgs

### DIFF
--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -80,6 +80,9 @@ The following tables lists the configurable parameters of the podinfo chart and 
 | `service.nodePort`                | `31198`                | NodePort for the HTTP endpoint                                                                                         |
 | `h2c.enabled`                     | `false`                | Allow upgrading to h2c (non-TLS version of HTTP/2)                                                                     |
 | `extraEnvs`                       | `[]`                   | Extra environment variables for the podinfo container |
+| `config.path`                     | `""`                   | config file path                                                                                                       |
+| `config.name`                     | `""`                   | config file name                                                                                                       |
+| `extraArgs`                       | `[]`                   | Additional command line arguments to pass to podinfo container                                                         |
 | `hpa.enabled`                     | `false`                | Enables the Kubernetes HPA                                                                                             |
 | `hpa.maxReplicas`                 | `10`                   | Maximum amount of pods                                                                                                 |
 | `hpa.cpu`                         | `None`                 | Target CPU usage per pod                                                                                               |

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -87,6 +87,15 @@ spec:
             {{- if .Values.h2c.enabled }}
             - --h2c
             {{- end }}
+            {{- with .Values.config.path }}
+            - --config-path={{ . }}
+            {{- end }}
+            {{- with .Values.config.name }}
+            - --config={{ . }}
+            {{- end }}
+            {{- with .Values.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
           {{- if .Values.ui.message }}
           - name: PODINFO_UI_MESSAGE

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -41,6 +41,16 @@ service:
 h2c:
   enabled: false
 
+# config file settings
+config:
+  # config file path
+  path: ""
+  # config file name
+  name: ""
+
+# Additional command line arguments to pass to podinfo container
+extraArgs: []
+
 # enable tls on the podinfo service
 tls:
   enabled: false

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -45,6 +45,16 @@ service:
 h2c:
   enabled: false
 
+# config file settings
+config:
+  # config file path
+  path: ""
+  # config file name
+  name: ""
+
+# Additional command line arguments to pass to podinfo container
+extraArgs: []
+
 # enable tls on the podinfo service
 tls:
   enabled: false


### PR DESCRIPTION
Signed-off-by: toyamagu2021 <toyamagu2021@gmail.com>

## Motivation

* Allow input `config` and `config-path`
* Allow input `extraArgs` to input arbitral options

## Modification

* add `config.name`, `config.path`, and `extraArgs` to chart

## Verification

* `config.name`, `config.path`

```yaml
config:
  path: "."
  name: "config.yaml"
```

```
$ helm template . -s templates/deployment.yaml
          command:
            - ./podinfo
            - --port=9898
            - --cert-path=/data/cert
            - --port-metrics=9797
            - --grpc-port=9999
            - --grpc-service-name=podinfo
            - --level=info
            - --random-delay=false
            - --random-error=false
            - --config-path=.
            - --config=config.yaml
```

* `extraArgs`

```
extraArgs:
- --test=test
```

```
$ helm template . -s templates/deployment.yaml
          command:
            - ./podinfo
            - --port=9898
            - --cert-path=/data/cert
            - --port-metrics=9797
            - --grpc-port=9999
            - --grpc-service-name=podinfo
            - --level=info
            - --random-delay=false
            - --random-error=false
            - --test=test
```