### PR TITLE
feature(chart): allow extraEnvs to be parst

### DIFF
--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -79,6 +79,7 @@ The following tables lists the configurable parameters of the podinfo chart and 
 | `service.grpcService`             | `podinfo`              | gPRC service name                                                                                                      |
 | `service.nodePort`                | `31198`                | NodePort for the HTTP endpoint                                                                                         |
 | `h2c.enabled`                     | `false`                | Allow upgrading to h2c (non-TLS version of HTTP/2)                                                                     |
+| `extraEnvs`                       | `[]`                   | Extra environment variables for the podinfo container |
 | `hpa.enabled`                     | `false`                | Enables the Kubernetes HPA                                                                                             |
 | `hpa.maxReplicas`                 | `10`                   | Maximum amount of pods                                                                                                 |
 | `hpa.cpu`                         | `None`                 | Target CPU usage per pod                                                                                               |

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -104,6 +104,9 @@ spec:
           - name: PODINFO_BACKEND_URL
             value: {{ .Values.backend }}
           {{- end }}
+          {{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.httpPort | default 9898 }}

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -131,6 +131,14 @@ resources:
     cpu: 100m
     memory: 64Mi
 
+# Extra environment variables for the podinfo container
+extraEnvs: []
+# Example on how to configure extraEnvs
+#  - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+#    value: "http://otel:4317"
+#  - name: MULTIPLE_VALUES
+#    value: TEST
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -134,6 +134,14 @@ resources:
     cpu: 1m
     memory: 16Mi
 
+# Extra environment variables for the podinfo container
+extraEnvs: []
+# Example on how to configure extraEnvs
+#  - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+#    value: "http://otel:4317"
+#  - name: MULTIPLE_VALUES
+#    value: TEST
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Motivation

- Allow input extraEnvs to input arbitral options

Modification

- add extraEnvs to chart

Verification

- values.entraEnvs

Values.yaml

    extraEnvs:
      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: "http://otel:4317"
      - name: MULTIPLE_VALUES
         value: TEST

$ helm template . -s templates/deployment.yaml

    env:
          - name: PODINFO_UI_COLOR
            value: "#34577c"
          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
            value: http://otel:4317
          - name: MULTIPLE_VALUES
            value: TEST