### PR TITLE
Added support for podSecurityContext in helm chart

### DIFF
--- a/charts/podinfo/README.md
+++ b/charts/podinfo/README.md
@@ -79,7 +79,7 @@ The following tables lists the configurable parameters of the podinfo chart and 
 | `service.grpcService`             | `podinfo`              | gPRC service name                                                                                                      |
 | `service.nodePort`                | `31198`                | NodePort for the HTTP endpoint                                                                                         |
 | `h2c.enabled`                     | `false`                | Allow upgrading to h2c (non-TLS version of HTTP/2)                                                                     |
-| `extraEnvs`                       | `[]`                   | Extra environment variables for the podinfo container |
+| `extraEnvs`                       | `[]`                   | Extra environment variables for the podinfo container                                                                  |
 | `config.path`                     | `""`                   | config file path                                                                                                       |
 | `config.name`                     | `""`                   | config file name                                                                                                       |
 | `extraArgs`                       | `[]`                   | Additional command line arguments to pass to podinfo container                                                         |
@@ -92,12 +92,13 @@ The following tables lists the configurable parameters of the podinfo chart and 
 | `serviceAccount.name`             | `None`                 | The name of the service account to use, if not set and create is true, a name is generated using the fullname template |
 | `serviceAccount.imagePullSecrets` | `[]`                   | List of image pull secrets if pulling from private registries.                                                         |
 | `securityContext`                 | `{}`                   | The security context to be set on the podinfo container                                                                |
+| `podSecurityContext`              | `{}`                   | The security context to be set on the pod                                                                              |
 | `linkerd.profile.enabled`         | `false`                | Create Linkerd service profile                                                                                         |
 | `serviceMonitor.enabled`          | `false`                | Whether a Prometheus Operator service monitor should be created                                                        |
 | `serviceMonitor.interval`         | `15s`                  | Prometheus scraping interval                                                                                           |
 | `serviceMonitor.additionalLabels` | `{}`                   | Add additional labels to the service monitor                                                                           |
 | `ingress.enabled`                 | `false`                | Enables Ingress                                                                                                        |
-| `ingress.className `              | `""`                   | Use ingressClassName                                                                                                   |
+| `ingress.className`               | `""`                    | Use ingressClassName                                                                                                  |
 | `ingress.additionalLabels`        | `{}`                   | Add additional labels to the ingress                                                                                   |
 | `ingress.annotations`             | `{}`                   | Ingress annotations                                                                                                    |
 | `ingress.hosts`                   | `[]`                   | Ingress accepted hosts                                                                                                 |

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -195,6 +195,10 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/podinfo/values-prod.yaml
+++ b/charts/podinfo/values-prod.yaml
@@ -107,6 +107,9 @@ serviceAccount:
 # set container security context
 securityContext: {}
 
+# set pod security context
+podSecurityContext: {}
+
 ingress:
   enabled: false
   className: ""

--- a/charts/podinfo/values.yaml
+++ b/charts/podinfo/values.yaml
@@ -111,6 +111,9 @@ serviceAccount:
 # set container security context
 securityContext: {}
 
+# set pod security context
+podSecurityContext: {}
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
I see it is supported in timoni but missing from the helm chart