### PR TITLE
feat(helm): Add namespace field to all resources

### DIFF
--- a/charts/podinfo/templates/NOTES.txt
+++ b/charts/podinfo/templates/NOTES.txt
@@ -6,15 +6,15 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "podinfo.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "podinfo.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "podinfo.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "podinfo.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "podinfo.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "podinfo.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "podinfo.namespace" . }} {{ template "podinfo.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl -n {{ .Release.Namespace }} port-forward deploy/{{ template "podinfo.fullname" . }} 8080:{{ .Values.service.externalPort }}
+  kubectl -n {{ include "podinfo.namespace" . }} port-forward deploy/{{ template "podinfo.fullname" . }} 8080:{{ .Values.service.externalPort }}
 {{- end }}

--- a/charts/podinfo/templates/_helpers.tpl
+++ b/charts/podinfo/templates/_helpers.tpl
@@ -24,6 +24,13 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "podinfo.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "podinfo.chart" -}}

--- a/charts/podinfo/templates/certificate.yaml
+++ b/charts/podinfo/templates/certificate.yaml
@@ -3,6 +3,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "podinfo.fullname" . }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
 spec:

--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "podinfo.fullname" . }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
 spec:

--- a/charts/podinfo/templates/hpa.yaml
+++ b/charts/podinfo/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "podinfo.fullname" . }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}  
 spec:

--- a/charts/podinfo/templates/ingress.yaml
+++ b/charts/podinfo/templates/ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
     {{- with .Values.ingress.additionalLabels }}

--- a/charts/podinfo/templates/linkerd.yaml
+++ b/charts/podinfo/templates/linkerd.yaml
@@ -2,7 +2,8 @@
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: {{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  name: {{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}.svc.cluster.local
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}  
 spec:

--- a/charts/podinfo/templates/pdb.yaml
+++ b/charts/podinfo/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "podinfo.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
 spec:

--- a/charts/podinfo/templates/service.yaml
+++ b/charts/podinfo/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "podinfo.fullname" . }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
 {{- with .Values.service.annotations }}

--- a/charts/podinfo/templates/servicemonitor.yaml
+++ b/charts/podinfo/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "podinfo.fullname" . }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}
@@ -15,7 +16,7 @@ spec:
       interval: {{ .Values.serviceMonitor.interval }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "podinfo.namespace" . }}
   selector:
     matchLabels:
       {{- include "podinfo.selectorLabels" . | nindent 6 }}

--- a/charts/podinfo/templates/tests/cache.yaml
+++ b/charts/podinfo/templates/tests/cache.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-cache-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:
@@ -24,6 +25,6 @@ spec:
           curl -s -XDELETE ${PODINFO_SVC}/cache/test
       env:
       - name: PODINFO_SVC
-        value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
+        value: "{{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}:{{ .Values.service.externalPort }}"
   restartPolicy: Never
 {{- end }}

--- a/charts/podinfo/templates/tests/fail.yaml
+++ b/charts/podinfo/templates/tests/fail.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-fault-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:

--- a/charts/podinfo/templates/tests/grpc.yaml
+++ b/charts/podinfo/templates/tests/grpc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-grpc-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:
@@ -15,5 +16,5 @@ spec:
     - name: grpc-health-probe
       image: stefanprodan/grpc_health_probe:v0.3.0
       command: ['grpc_health_probe']
-      args:  ['-addr={{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.grpcPort }}']
+      args:  ['-addr={{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}:{{ .Values.service.grpcPort }}']
   restartPolicy: Never

--- a/charts/podinfo/templates/tests/jwt.yaml
+++ b/charts/podinfo/templates/tests/jwt.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-jwt-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:
@@ -22,5 +23,5 @@ spec:
           curl -sH "Authorization: Bearer ${TOKEN}" ${PODINFO_SVC}/token/validate | grep test
       env:
       - name: PODINFO_SVC
-        value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
+        value: "{{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}:{{ .Values.service.externalPort }}"
   restartPolicy: Never

--- a/charts/podinfo/templates/tests/service.yaml
+++ b/charts/podinfo/templates/tests/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-service-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:
@@ -21,5 +22,5 @@ spec:
           curl -s ${PODINFO_SVC}/api/info | grep version
       env:
         - name: PODINFO_SVC
-          value: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.externalPort }}"
+          value: "{{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}:{{ .Values.service.externalPort }}"
   restartPolicy: Never

--- a/charts/podinfo/templates/tests/timeout.yaml
+++ b/charts/podinfo/templates/tests/timeout.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-fault-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:

--- a/charts/podinfo/templates/tests/tls.yaml
+++ b/charts/podinfo/templates/tests/tls.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "podinfo.fullname" . }}-tls-test-{{ randAlphaNum 5 | lower }}
+  namespace: {{ include "podinfo.namespace" . }}
   labels:
     {{- include "podinfo.labels" . | nindent 4 }}
   annotations:
@@ -22,6 +23,6 @@ spec:
           curl -sk ${PODINFO_SVC}/api/info | grep version
       env:
         - name: PODINFO_SVC
-          value: "https://{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.tls.port }}"
+          value: "https://{{ template "podinfo.fullname" . }}.{{ include "podinfo.namespace" . }}:{{ .Values.tls.port }}"
   restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
In this PR I added two things:
- `metadata.namespace` to all (namespaced) resources
- ability to override this field to a custom namespace by adopting the "community standard" `.Values.namespaceOverride`

Some more details:

## Add `metadata.namespace`

There are tools which uses Helm only for templating (equivalent to `helm template .`):
- Kustomize (with `--enable-helm`)
- Argo CD
- CI scripts like
  - `helm template . | kubeconform ...`
  - `helm template . | kyverno apply -f -` (this is what I need for this chart 😄)

## Override via `.Values.namespaceOverride`

While I added the first "feature" to all resources, I thought that I create the common helper inside `_helpers.tpl` and add this to all resources instead of `{{ .Release.Namespace}}`.

I think the Helm chart community is heavily influenced by the Bitnami helm charts, they all support this, and many more.

## external references around those features:
- https://github.com/prometheus-community/helm-charts/issues/3472
- https://github.com/prometheus-community/helm-charts/pull/1878
- https://github.com/helm/charts/pull/18990
- https://github.com/helm/charts/pull/22288
- https://github.com/helm/charts/pull/18986
- https://github.com/kubernetes/ingress-nginx/pull/10539