### PR TITLE
feat(charts): update deployment to include serviceAccountName

### DIFF
--- a/charts/podinfo/templates/deployment.yaml
+++ b/charts/podinfo/templates/deployment.yaml
@@ -28,9 +28,7 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 30
-      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ template "podinfo.serviceAccountName" . }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
- Remove the conditional check `{{- if .Values.serviceAccount.enabled }}`
- Always add `.spec.template.spec.serviceAccountName`, 2 possible values for this:
  - `{{- if .Values.serviceAccount.name }}` then use this `.Values.serviceAccount.name`
  - If not defined, we use `default` (this `ServiceAccount` is always there)

This is to solve the use case where you have an existing `ServiceAccount` and want to use that (for e.g. Vault service account to pull secrets), instead of the `default`. But the conditional check `{{- if .Values.serviceAccount.enabled }}` will remove that capability.