### PR TITLE
fix: set Content-Type to prevent MIME-sniff XSS (CVE-2026-43644)

### DIFF
--- a/pkg/api/http/echo.go
+++ b/pkg/api/http/echo.go
@@ -102,6 +102,9 @@ func (s *Server) echoHandler(w http.ResponseWriter, r *http.Request) {
 		s.JSONResponse(w, r, result)
 
 	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'")
 		w.Header().Set("X-Color", s.config.UIColor)
 		w.WriteHeader(http.StatusAccepted)
 		w.Write(body)

--- a/pkg/api/http/echo_test.go
+++ b/pkg/api/http/echo_test.go
@@ -46,3 +46,31 @@ func TestEchoHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestEchoHandler_ContentType(t *testing.T) {
+	srv := NewMockServer()
+	handler := http.HandlerFunc(srv.echoHandler)
+
+	payload := "<html><script>alert(1)</script></html>"
+	req, err := http.NewRequest("POST", "/echo", strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("echo returned status %d, want %d", rr.Code, http.StatusAccepted)
+	}
+
+	expectedHeaders := map[string]string{
+		"Content-Type":            "application/octet-stream",
+		"X-Content-Type-Options":  "nosniff",
+		"Content-Security-Policy": "default-src 'none'",
+	}
+	for header, want := range expectedHeaders {
+		if got := rr.Header().Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #474.  Sets explicit Content-Type + X-Content-Type-Options: nosniff + CSP before the write.