### PR TITLE
build: bump base image from alpine:3.23 to alpine:3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w \
     -X github.com/stefanprodan/podinfo/pkg/version.REVISION=${REVISION}" \
     -a -o bin/podcli cmd/podcli/*
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
## Summary

Fixes #502.

The reporter's security scanner (JFrog Xray via Artifactory) flagged CVEs against the `stefanprodan/podinfo` Docker Hub image, but no specific CVE IDs were available. I scanned the published `stefanprodan/podinfo:latest` image (built 2026-06-18 on Alpine 3.23.4) with Trivy to find out what's actually there.

**Findings on the published image:**

| CVE | Severity | Package |
|---|---|---|
| CVE-2026-33630 | HIGH | c-ares 1.34.6 |
| CVE-2026-5773 | HIGH | curl/libcurl 8.19.0 |
| CVE-2026-6276 | HIGH | curl/libcurl 8.19.0 |
| CVE-2026-45447 | HIGH | libssl3/libcrypto3 (openssl) 3.5.6 |
| + 6 more MEDIUM curl CVEs, 4 more MEDIUM openssl CVEs | | |

None of these are Go module vulnerabilities — `govulncheck` finds nothing against the source. They're all Alpine OS package CVEs disclosed *after* the image was built and published; the Dockerfile itself hadn't changed, but pinned `alpine:3.23` had drifted from patch `3.23.4` (in the published image) to the CVE-carrying state as new advisories landed against those package versions.

## Change

One-line bump: `FROM alpine:3.23` → `FROM alpine:3.24` (currently resolves to `3.24.1`).

## Test plan

- [x] Built the image locally with the updated Dockerfile
- [x] Scanned with Trivy (`trivy image --severity CRITICAL,HIGH,MEDIUM`): **0 vulnerabilities** found across Alpine packages and both Go binaries (`podinfo`, `podcli`)
- [x] Ran the container and confirmed `/healthz` responds `200 OK`

Note: this only patches the currently-known CVE set at time of this PR — since these are OS package CVEs, periodic rebuilds/republishes of the image (independent of source changes) will still be needed as new advisories land against whatever Alpine version is pinned.